### PR TITLE
CI: Use release build to run tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
       platform: linux-x64
       bootjdk-platform: linux-x64
       runs-on: ubuntu-22.04
-      debug-level: fastdebug
+      debug-level: release
 
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:


### PR DESCRIPTION
With release build test time is reduced to ~30 minutes, before it can take up to 1h30min.