### PR TITLE
Fix atomic_set_bits crash when defineAnonymousClass return null

### DIFF
--- a/src/hotspot/share/prims/unsafe8.cpp
+++ b/src/hotspot/share/prims/unsafe8.cpp
@@ -640,9 +640,10 @@ UNSAFE_ENTRY(jclass, Unsafe_DefineAnonymousClass(JNIEnv *env, jobject unsafe, jc
   anon_klass = Unsafe_DefineAnonymousClass_impl(env, host_class, data,
                                                 cp_patches_jh,
                                                    &temp_alloc, THREAD);
-  anon_klass->set_is_hidden();
-  if (anon_klass != NULL)
+  if (anon_klass != NULL) {
+    anon_klass->set_is_hidden();
     res_jh = JNIHandles::make_local(THREAD, anon_klass->java_mirror());
+  }
 
   // try/finally clause:
   if (temp_alloc != NULL) {


### PR DESCRIPTION
# Problematic frame:
# V  [libjvm.so+0x29d890]  AccessFlags::atomic_set_bits(int)+0x0
#


Stack: [0x00007fed02200000,0x00007fed02301000],  sp=0x00007fed022fe308,  free space=1016k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x29d890]  AccessFlags::atomic_set_bits(int)+0x0
J 9638  sun.misc.Unsafe.defineAnonymousClass(Ljava/lang/Class;[B[Ljava/lang/Object;)Ljava/#
J 20991 c1 java.lang.invoke.InnerClassLambdaMetafactory.spinInnerClass()Ljava/lang/Class; #
J 16577 c1 java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite()Ljava/lang/invoke/C#
J 17751 c1 java.lang.invoke.LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$#
...