### PR TITLE
alt_app: Add -heap support for jmap17

### DIFF
--- a/cvm/alt_app/tools17/src/share/classes/sun/tools/jmap/HotSpotVirtualMachine.java
+++ b/cvm/alt_app/tools17/src/share/classes/sun/tools/jmap/HotSpotVirtualMachine.java
@@ -1,0 +1,365 @@
+// This project is a modified version of OpenJDK, licensed under GPL v2.
+// Modifications Copyright (C) 2025 ByteDance Inc.
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.tools.attach;
+
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.AgentLoadException;
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.spi.AttachProvider;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/*
+ * The HotSpot implementation of com.sun.tools.attach.VirtualMachine.
+ */
+
+public abstract class HotSpotVirtualMachine extends VirtualMachine {
+
+    HotSpotVirtualMachine(AttachProvider provider, String id) {
+        super(provider, id);
+    }
+
+    /*
+     * Load agent library
+     * If isAbsolute is true then the agent library is the absolute path
+     * to the library and thus will not be expanded in the target VM.
+     * if isAbsolute is false then the agent library is just a library
+     * name and it will be expended in the target VM.
+     */
+    private void loadAgentLibrary(String agentLibrary, boolean isAbsolute, String options)
+        throws AgentLoadException, AgentInitializationException, IOException
+    {
+        InputStream in = execute("load",
+                                 agentLibrary,
+                                 isAbsolute ? "true" : "false",
+                                 options);
+        try {
+            int result = readInt(in);
+            if (result != 0) {
+                throw new AgentInitializationException("Agent_OnAttach failed", result);
+            }
+        } finally {
+            in.close();
+
+        }
+    }
+
+    /*
+     * Load agent library - library name will be expanded in target VM
+     */
+    public void loadAgentLibrary(String agentLibrary, String options)
+        throws AgentLoadException, AgentInitializationException, IOException
+    {
+        loadAgentLibrary(agentLibrary, false, options);
+    }
+
+    /*
+     * Load agent - absolute path of library provided to target VM
+     */
+    public void loadAgentPath(String agentLibrary, String options)
+        throws AgentLoadException, AgentInitializationException, IOException
+    {
+        loadAgentLibrary(agentLibrary, true, options);
+    }
+
+    /*
+     * Load JPLIS agent which will load the agent JAR file and invoke
+     * the agentmain method.
+     */
+    public void loadAgent(String agent, String options)
+        throws AgentLoadException, AgentInitializationException, IOException
+    {
+        String args = agent;
+        if (options != null) {
+            args = args + "=" + options;
+        }
+        try {
+            loadAgentLibrary("instrument", args);
+        } catch (AgentLoadException x) {
+            throw new InternalError("instrument library is missing in target VM", x);
+        } catch (AgentInitializationException x) {
+            /*
+             * Translate interesting errors into the right exception and
+             * message (FIXME: create a better interface to the instrument
+             * implementation so this isn't necessary)
+             */
+            int rc = x.returnValue();
+            switch (rc) {
+                case JNI_ENOMEM:
+                    throw new AgentLoadException("Insuffient memory");
+                case ATTACH_ERROR_BADJAR:
+                    throw new AgentLoadException("Agent JAR not found or no Agent-Class attribute");
+                case ATTACH_ERROR_NOTONCP:
+                    throw new AgentLoadException("Unable to add JAR file to system class path");
+                case ATTACH_ERROR_STARTFAIL:
+                    throw new AgentInitializationException("Agent JAR loaded but agent failed to initialize");
+                default :
+                    throw new AgentLoadException("Failed to load agent - unknown reason: " + rc);
+            }
+        }
+    }
+
+    /*
+     * The possible errors returned by JPLIS's agentmain
+     */
+    private static final int JNI_ENOMEM                 = -4;
+    private static final int ATTACH_ERROR_BADJAR        = 100;
+    private static final int ATTACH_ERROR_NOTONCP       = 101;
+    private static final int ATTACH_ERROR_STARTFAIL     = 102;
+
+
+    /*
+     * Send "properties" command to target VM
+     */
+    public Properties getSystemProperties() throws IOException {
+        InputStream in = null;
+        Properties props = new Properties();
+        try {
+            in = executeCommand("properties");
+            props.load(in);
+        } finally {
+            if (in != null) in.close();
+        }
+        return props;
+    }
+
+    public Properties getAgentProperties() throws IOException {
+        InputStream in = null;
+        Properties props = new Properties();
+        try {
+            in = executeCommand("agentProperties");
+            props.load(in);
+        } finally {
+            if (in != null) in.close();
+        }
+        return props;
+    }
+
+    private static final String MANAGMENT_PREFIX = "com.sun.management.";
+
+    private static boolean checkedKeyName(Object key) {
+        if (!(key instanceof String)) {
+            throw new IllegalArgumentException("Invalid option (not a String): "+key);
+        }
+        if (!((String)key).startsWith(MANAGMENT_PREFIX)) {
+            throw new IllegalArgumentException("Invalid option: "+key);
+        }
+        return true;
+    }
+
+    private static String stripKeyName(Object key) {
+        return ((String)key).substring(MANAGMENT_PREFIX.length());
+    }
+
+    @Override
+    public void startManagementAgent(Properties agentProperties) throws IOException {
+        if (agentProperties == null) {
+            throw new NullPointerException("agentProperties cannot be null");
+        }
+        // Convert the arguments into arguments suitable for the Diagnostic Command:
+        // "ManagementAgent.start jmxremote.port=5555 jmxremote.authenticate=false"
+        String args = agentProperties.entrySet().stream()
+            .filter(entry -> checkedKeyName(entry.getKey()))
+            .map(entry -> stripKeyName(entry.getKey()) + "=" + escape(entry.getValue()))
+            .collect(Collectors.joining(" "));
+        executeJCmd("ManagementAgent.start " + args);
+    }
+
+    private String escape(Object arg) {
+        String value = arg.toString();
+        if (value.contains(" ")) {
+            return "'" + value + "'";
+        }
+        return value;
+    }
+
+    @Override
+    public String startLocalManagementAgent() throws IOException {
+        executeJCmd("ManagementAgent.start_local");
+        return getAgentProperties().getProperty("com.sun.management.jmxremote.localConnectorAddress");
+    }
+
+    // --- HotSpot specific methods ---
+
+    // same as SIGQUIT
+    public void localDataDump() throws IOException {
+        executeCommand("datadump").close();
+    }
+
+    // Remote ctrl-break. The output of the ctrl-break actions can
+    // be read from the input stream.
+    public InputStream remoteDataDump(Object ... args) throws IOException {
+        return executeCommand("threaddump", args);
+    }
+
+    // Remote heap dump. The output (error message) can be read from the
+    // returned input stream.
+    public InputStream dumpHeap(Object ... args) throws IOException {
+        return executeCommand("dumpheap", args);
+    }
+
+    // Heap histogram (heap inspection in HotSpot)
+    public InputStream heapHisto(Object ... args) throws IOException {
+        return executeCommand("inspectheap", args);
+    }
+
+    // Heap Summary
+    public InputStream heapSummary() throws IOException {
+        return executeCommand("heapsummary");
+    }
+
+    // set JVM command line flag
+    public InputStream setFlag(String name, String value) throws IOException {
+        return executeCommand("setflag", name, value);
+    }
+
+    // print command line flag
+    public InputStream printFlag(String name) throws IOException {
+        return executeCommand("printflag", name);
+    }
+
+    public InputStream executeJCmd(String command) throws IOException {
+        return executeCommand("jcmd", command);
+    }
+
+    // -- Supporting methods
+
+
+    /*
+     * Execute the given command in the target VM - specific platform
+     * implementation must implement this.
+     */
+    abstract InputStream execute(String cmd, Object ... args)
+        throws AgentLoadException, IOException;
+
+    /*
+     * Convenience method for simple commands
+     */
+    private InputStream executeCommand(String cmd, Object ... args) throws IOException {
+        try {
+            return execute(cmd, args);
+        } catch (AgentLoadException x) {
+            throw new InternalError("Should not get here", x);
+        }
+    }
+
+
+    /*
+     * Utility method to read an 'int' from the input stream. Ideally
+     * we should be using java.util.Scanner here but this implementation
+     * guarantees not to read ahead.
+     */
+    int readInt(InputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        // read to \n or EOF
+        int n;
+        byte buf[] = new byte[1];
+        do {
+            n = in.read(buf, 0, 1);
+            if (n > 0) {
+                char c = (char)buf[0];
+                if (c == '\n') {
+                    break;                  // EOL found
+                } else {
+                    sb.append(c);
+                }
+            }
+        } while (n > 0);
+
+        if (sb.length() == 0) {
+            throw new IOException("Premature EOF");
+        }
+
+        int value;
+        try {
+            value = Integer.parseInt(sb.toString());
+        } catch (NumberFormatException x) {
+            throw new IOException("Non-numeric value found - int expected");
+        }
+        return value;
+    }
+
+    /*
+     * Utility method to read data into a String.
+     */
+    String readErrorMessage(InputStream sis) throws IOException {
+        byte b[] = new byte[1024];
+        int n;
+        StringBuffer message = new StringBuffer();
+        while ((n = sis.read(b)) != -1) {
+            message.append(new String(b, 0, n, "UTF-8"));
+        }
+        return message.toString();
+    }
+
+
+    // -- attach timeout support
+
+    private static long defaultAttachTimeout = 5000;
+    private volatile long attachTimeout;
+
+    /*
+     * Return attach timeout based on the value of the sun.tools.attach.attachTimeout
+     * property, or the default timeout if the property is not set to a positive
+     * value.
+     */
+    long attachTimeout() {
+        if (attachTimeout == 0) {
+            synchronized(this) {
+                if (attachTimeout == 0) {
+                    try {
+                        String s =
+                            System.getProperty("sun.tools.attach.attachTimeout");
+                        attachTimeout = Long.parseLong(s);
+                    } catch (SecurityException se) {
+                    } catch (NumberFormatException ne) {
+                    }
+                    if (attachTimeout <= 0) {
+                       attachTimeout = defaultAttachTimeout;
+                    }
+                }
+            }
+        }
+        return attachTimeout;
+    }
+
+    protected static void checkNulls(Object... args) {
+        for (Object arg : args) {
+            if (arg instanceof String) {
+                String s = (String)arg;
+                if (s.indexOf(0) >= 0) {
+                    throw new IllegalArgumentException("illegal null character in command");
+                }
+            }
+        }
+    }
+}

--- a/cvm/alt_app/tools17/src/share/classes/sun/tools/jmap/JMap17.java
+++ b/cvm/alt_app/tools17/src/share/classes/sun/tools/jmap/JMap17.java
@@ -107,7 +107,9 @@ public class JMap17 {
             executeCommandForPid(pid, "jcmd", "GC.finalizer_info");
         } else if (option.equals("-clstats")) {
             executeCommandForPid(pid, "jcmd", "VM.classloader_stats");
-        } else {
+        } else if (option.equals("-heap")) {
+            executeCommandForPid(pid, "heapsummary");
+	} else {
           usage(1);
         }
     }
@@ -143,6 +145,8 @@ public class JMap17 {
             return vm.heapHisto(args);
           case "dumpheap":
             return vm.dumpHeap(args);
+          case "heapsummary":
+            return vm.heapSummary();
           default:
             throw new IllegalArgumentException("Unexpected command: " + command);
         }
@@ -262,9 +266,6 @@ public class JMap17 {
                 SAOptionError("-F option used");
             }
 
-            if (s.equals("-heap")) {
-                SAOptionError("-heap option used");
-            }
 
             /* Reimplemented using jcmd, output format is different
                from original one

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -223,6 +223,11 @@ public:
   size_t young_gen_committed()        { return _young_gen_committed; }
 
   size_t eden_space_used()            { return _eden_space_used; }
+#if HOTSPOT_TARGET_CLASSLIB == 8
+  size_t eden_space_committed()       { return _eden_space_committed; }
+  size_t survivor_space_committed()   { return _survivor_space_committed; }
+#endif
+
   size_t survivor_space_used()        { return _survivor_space_used; }
 
   size_t old_gen_committed()          { return _old_gen_committed; }

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -29,6 +29,12 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "gc/shared/gcVMOperations.hpp"
+#if HOTSPOT_TARGET_CLASSLIB == 8
+#include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/parallel/parallelScavengeHeap.hpp"
+#include "gc/serial/defNewGeneration.hpp"
+#include "gc/z/zCollectedHeap.hpp"
+#endif
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
@@ -361,6 +367,146 @@ static jint print_flag(AttachOperation* op, outputStream* out) {
   return JNI_OK;
 }
 
+#if HOTSPOT_TARGET_CLASSLIB == 8
+unsigned long MAX_ULONG = (unsigned long)-1;
+
+// printf heap info to outstream
+void print_heap_info(outputStream* out, const char name[], unsigned long capacity, unsigned long used, unsigned long regions = MAX_ULONG) {
+  out->print_cr("%s", name);
+  if (regions != MAX_ULONG)
+    out->print_cr("\tregions:    = %lu", regions);
+  out->print_cr("\tcapacity:   = %lu (%.3f MB)", capacity, (double) 1.0 * capacity / (1 << 20));
+  out->print_cr("\tused:       = %lu (%.3f MB)", used, (double) 1.0 * used / (1 << 20));
+  out->print_cr("\tfree:       = %lu (%.3f MB)", capacity - used, (double) 1.0 * (capacity - used) / (1 << 20));
+  double occu = capacity > 0 ? (double) 100.0 * used / capacity : 0;
+  out->print_cr("\t%f%% used", occu);
+}
+
+// Implementation of "heap" command
+// See also: HeapSummary class
+static jint heap_summary(AttachOperation* op, outputStream* out) {
+  const char* arg0 = op->arg(0);
+  if (arg0 != NULL && (strlen(arg0) > 0)) {
+    out->print_cr("Invalid argument to inspectheap operation: %s", arg0);
+    return JNI_ERR;
+  }
+
+  // some necessary info in out
+  //1.  UseTLB?
+  if(UseTLAB) {
+    out->print_cr("using thread-local object allocation.");
+  }
+
+  //2. gc algorithm
+  if (UseParallelGC) {
+    out->print_cr("Parallel GC ParallelGCThreads with %d thread(s)", ParallelGCThreads);
+  } else if (UseG1GC){
+    out->print_cr("Garbage-First (G1) GC ParallelGCThreads with %d thread(s)", ParallelGCThreads);
+  } else if (UseZGC) {
+    out->print_cr("ZGC ParallelGCThreads with %d thread(s)", ParallelGCThreads);
+  } else if (UseShenandoahGC) {
+    out->print_cr("Shenandoah GC ParallelGCThreads with %d thread(s)", ParallelGCThreads);
+  } else {
+    out->print_cr("Mark Sweep Compact GC");
+  }
+
+  out->print_cr("");
+
+  out->print_cr("Heap Configuration:");
+
+  out->print_cr("\tMinHeapFreeRatio         = %lu", MinHeapFreeRatio);
+  out->print_cr("\tMaxHeapFreeRatio         = %lu", MaxHeapFreeRatio);
+  out->print_cr("\tMaxHeapSize              = %lu (%.3f MB)", MaxHeapSize, (double) 1.0 * MaxHeapSize / (1 << 20));
+  out->print_cr("\tNewSize                  = %lu (%.3f MB)", NewSize, (double) 1.0 * NewSize / (1 << 20));
+  out->print_cr("\tMaxNewSize               = %lu (%.3f MB)", MaxNewSize, (double) 1.0 * MaxNewSize / (1 << 20));
+  out->print_cr("\tOldSize                  = %lu (%.3f MB)", OldSize, (double) 1.0 * OldSize / (1 << 20));
+  out->print_cr("\tNewRatio                 = %lu", NewRatio);
+  out->print_cr("\tSurvivorRatio            = %lu", SurvivorRatio);
+  out->print_cr("\tMetaspaceSize            = %lu (%.3f MB)", MetaspaceSize, (double) 1.0 * MetaspaceSize / (1 << 20));
+  out->print_cr("\tCompressedClassSpaceSize = %lu (%.3f MB)", CompressedClassSpaceSize, (double) 1.0 * CompressedClassSpaceSize / (1 << 20));
+  out->print_cr("\tMaxMetaspaceSize         = %lu (%.3f MB)", MaxMetaspaceSize, (double) 1.0 * MaxMetaspaceSize / (1 << 20));
+  if (UseShenandoahGC) {
+     out->print_cr("\tShenandoahRegionSize     = %lu (%.3f MB)", ShenandoahHeapRegion::region_size_bytes(), (double) 1.0 * ShenandoahHeapRegion::region_size_bytes() / (1 << 20));
+  } else {
+     out->print_cr("\tG1HeapRegionSize         = %lu (%.3f MB)", G1HeapRegionSize, (double) 1.0 * G1HeapRegionSize / (1 << 20));
+  }
+
+  out->print_cr("\nHeap Usage:");
+
+  // Try default G1GC first
+  if (UseG1GC) {
+    G1CollectedHeap *g1gc = G1CollectedHeap::heap();
+    G1MonitoringSupport *monitorSupport = g1gc->g1mm();
+
+    print_heap_info(out, "G1 Heap:",
+        g1gc->max_reserved_regions() * HeapRegion::GrainBytes,
+        g1gc->used_unlocked(),
+        g1gc->max_reserved_regions());
+
+    out->print_cr("G1 Young Generation:");
+    print_heap_info(out, "Eden Space:",
+        monitorSupport->eden_space_committed(),
+        monitorSupport->eden_space_used(),
+        monitorSupport->eden_space_used() / HeapRegion::GrainBytes);
+    print_heap_info(out, "Survivor Space:",
+        monitorSupport->survivor_space_committed(),
+        monitorSupport->survivor_space_used(),
+        monitorSupport->survivor_space_used() / HeapRegion::GrainBytes);
+    print_heap_info(out, "G1 Old Generation:", // HINT: this mismatch with jdk17, check again
+        monitorSupport->old_gen_committed(),
+        monitorSupport->old_gen_used(),
+        g1gc->old_regions_count() + g1gc->archive_regions_count() + g1gc->humongous_regions_count());
+  } else if (UseParallelGC) {
+    ParallelScavengeHeap *parallel = ParallelScavengeHeap::heap();
+    PSYoungGen *young_gen = parallel->young_gen();
+    PSOldGen *old_gen = parallel->old_gen();
+    out->print_cr("PS Young Generation");
+    print_heap_info(out, "Eden Space:",
+        young_gen->eden_space()->capacity_in_bytes(),
+        young_gen->eden_space()->used_in_bytes());
+    print_heap_info(out, "From Space:",
+        young_gen->from_space()->capacity_in_bytes(),
+        young_gen->from_space()->used_in_bytes());
+    print_heap_info(out, "To Space:",
+        young_gen->to_space()->capacity_in_bytes(),
+        young_gen->to_space()->used_in_bytes());
+    print_heap_info(out, "PS Old Generation",
+        old_gen->capacity_in_bytes(),
+        old_gen->used_in_bytes());
+  } else if (UseSerialGC) {
+    GenCollectedHeap *serial = GenCollectedHeap::heap();
+    DefNewGeneration *young = (DefNewGeneration*)(serial->young_gen());
+    Generation *old = serial->old_gen();
+    print_heap_info(out, "New Generation (Eden + 1 Survivor Space):",
+        young->capacity(),
+        young->used());
+    print_heap_info(out, "Eden Space:",
+        young->eden()->capacity(),
+        young->eden()->used());
+    print_heap_info(out, "From Space:",
+        young->from()->capacity(),
+        young->from()->used());
+    print_heap_info(out, "To Space:",
+        young->to()->capacity(),
+        young->to()->used());
+    print_heap_info(out, old->name(),
+        old->capacity(),
+        old->used());
+  } else if (UseShenandoahGC) {
+    ShenandoahHeap *shenando = ShenandoahHeap::heap();
+    out->print_cr("\tregions:    = %lu", shenando->num_regions());
+    out->print_cr("\tcapacity:   = %lu (%.3f MB)", shenando->num_regions() * ShenandoahHeapRegion::region_size_bytes(), (double) 1.0 * shenando->num_regions() * ShenandoahHeapRegion::region_size_bytes() / (1 << 20));
+    out->print_cr("\tused:       = %lu (%.3f MB)", shenando->used(), (double) 1.0 * shenando->used() / (1 << 20));
+    out->print_cr("\tcommitted   = %lu (%.3f MB)", shenando->committed(), (double) 1.0 * shenando->committed() / (1 << 20));
+  } else if (UseZGC) {
+    ZCollectedHeap *zgc = ZCollectedHeap::heap();
+    zgc->print_on(out);
+  }
+  return JNI_OK;
+}
+
+#endif
+
 // Table to map operation names to functions.
 
 // names must be of length <= AttachOperation::name_length_max
@@ -375,6 +521,9 @@ static AttachOperationFunctionInfo funcs[] = {
   { "setflag",          set_flag },
   { "printflag",        print_flag },
   { "jcmd",             jcmd },
+#if HOTSPOT_TARGET_CLASSLIB == 8
+  { "heapsummary",      heap_summary},
+#endif
   { NULL,               NULL }
 };
 


### PR DESCRIPTION
`jmap -heap` option was supported in jdk 8 but deprecated in jdk17, this CL re-add this option in jmap17 for backward compatibility.

Since ShanandoGC && ZGC are not supported in jdk8, we align the print format of these GC algorithm to jdk17.

author:sunruinan