### PR TITLE
hotspot: Fix IllegalAccessError related to modules and MethodAccessor…

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -325,6 +325,15 @@ void LinkResolver::check_klass_accessibility(Klass* ref_klass, Klass* sel_klass,
 
     // Names are all known to be < 64k so we know this formatted message is not excessively large.
 
+#if HOTSPOT_TARGET_CLASSLIB == 8
+    if (msg == NULL) {
+      Exceptions::fthrow(
+        THREAD_AND_LOCATION,
+        vmSymbols::java_lang_IllegalAccessError(),
+        "failed to access class %s from class %s",
+        base_klass->external_name(),
+        ref_klass->external_name());
+#else
     bool same_module = (base_klass->module() == ref_klass->module());
     if (msg == nullptr) {
       Exceptions::fthrow(
@@ -336,6 +345,7 @@ void LinkResolver::check_klass_accessibility(Klass* ref_klass, Klass* sel_klass,
         (same_module) ? base_klass->joint_in_module_of_loader(ref_klass) : base_klass->class_in_module_of_loader(),
         (same_module) ? "" : "; ",
         (same_module) ? "" : ref_klass->class_in_module_of_loader());
+#endif // HOTSPOT_TARGET_CLASSLIB
     } else {
       // Use module specific message returned by verify_class_access_msg().
       Exceptions::fthrow(
@@ -599,6 +609,15 @@ void LinkResolver::check_method_accessability(Klass* ref_klass,
   if (!can_access) {
     ResourceMark rm(THREAD);
     stringStream ss;
+#if HOTSPOT_TARGET_CLASSLIB == 8
+    ss.print("class %s tried to access %s%s%smethod '%s'",
+             ref_klass->external_name(),
+             sel_method->is_abstract()  ? "abstract "  : "",
+             sel_method->is_protected() ? "protected " : "",
+             sel_method->is_private()   ? "private "   : "",
+             sel_method->external_name()
+             );
+#else
     bool same_module = (sel_klass->module() == ref_klass->module());
     ss.print("class %s tried to access %s%s%smethod '%s' (%s%s%s)",
              ref_klass->external_name(),
@@ -610,6 +629,7 @@ void LinkResolver::check_method_accessability(Klass* ref_klass,
              (same_module) ? "" : "; ",
              (same_module) ? "" : sel_klass->class_in_module_of_loader()
              );
+#endif // HOTSPOT_TARGET_CLASSLIB
 
     // For private access see if there was a problem with nest host
     // resolution, and if so report that as part of the message.

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -448,6 +448,15 @@ Reflection::VerifyClassAccessResults Reflection::verify_class_access(
     return ACCESS_OK;
   }
 
+#if HOTSPOT_TARGET_CLASSLIB == 8
+  // Allow all accesses from jdk/internal/reflect/MagicAccessorImpl subclasses to
+  // succeed trivially.
+  if (vmClasses::reflect_MagicAccessorImpl_klass_is_loaded() &&
+      current_class->is_subclass_of(vmClasses::reflect_MagicAccessorImpl_klass())) {
+    return ACCESS_OK;
+  }
+#endif
+
   // module boundaries
   if (new_class->is_public()) {
   #if HOTSPOT_TARGET_CLASSLIB == 8
@@ -653,6 +662,14 @@ bool Reflection::verify_member_access(const Klass* current_class,
       }
     }
   }
+
+#if HOTSPOT_TARGET_CLASSLIB == 8
+  // Allow all accesses from jdk/internal/reflect/MagicAccessorImpl subclasses to
+  // succeed trivially.
+  if (current_class->is_subclass_of(vmClasses::reflect_MagicAccessorImpl_klass())) {
+    return true;
+  }
+#endif
 
   // Check for special relaxations
   return can_relax_access_check_for(current_class, member_class, classloader_only);


### PR DESCRIPTION
1. ignore modules in method and klass accessibility check
2. allow reflection generated reflect_MagicAccessorImpl subclasses to access their parents

```
➜ python3 cmp_jtreg.py baseline fix
------------------ summary ------------------
[baseline] baseline: total=1321, passed=1141, failed=175, error=5
[newtest] fix: total=1321, passed=1206, failed=110, error=5
------------------ details ------------------
1 new 'failed' tests found in fix:
  java/lang/invoke/MethodHandles/CatchExceptionTest.java
No new 'error' tests from fix
------------------ end ------------------
```

The reported new failure is about string c2, which is likely a separate issue.

```
 #  Internal Error (src/hotspot/share/ci/ciTypeArray.cpp:56), pid=2541412, tid=2541428
 #  assert(index >= 0 && index < length()) failed: out of range
 #
 # JRE version: OpenJDK Runtime Environment ByteDance Testing (25.0) (slowdebug build 25)
 # Java VM: OpenJDK 64-Bit Server VM ByteDance Testing (slowdebug 25, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
 # Problematic frame:
 # V  [libjvm.so+0xa32a88]  ciTypeArray::byte_at(int)+0x90
```