### PR TITLE
make attach stream_output as false to support v1 protocal in jdk8

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -172,8 +172,13 @@ volatile AttachListenerState AttachListener::_state = AL_NOT_INITIALIZED;
 
 AttachAPIVersion AttachListener::_supported_version = ATTACH_API_V1;
 
+#if HOTSPOT_TARGET_CLASSLIB == 8
+// Default is false for v1 in JDK8.
+bool AttachListener::_default_streaming_output = false;
+#else
 // Default is true (if jdk.attach.vm.streaming property is not set).
 bool AttachListener::_default_streaming_output = true;
+#endif
 
 static bool get_bool_sys_prop(const char* name, bool default_value, TRAPS) {
   ResourceMark rm(THREAD);


### PR DESCRIPTION
1. JDK8 support attach protocal v1
2. JDK25 support attach protocal v1 and v2
3. stream_output default is enabled, it will block the whole process in v1 when self attach case