### PR TITLE
Disabled JFR event on_klass_creation (unavailable in jdk8u) to fix java/lang/Class/getDeclaredField/FieldSetAccessibleTest

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -78,6 +78,7 @@ void Jfr::on_unloading_classes() {
   }
 }
 
+#if HOTSPOT_TARGET_CLASSLIB != 8
 void Jfr::on_klass_creation(InstanceKlass*& ik, ClassFileParser& parser, TRAPS) {
   if (IS_EVENT_OR_HOST_KLASS(ik)) {
     JfrEventClassTransformer::on_klass_creation(ik, parser, THREAD);
@@ -87,6 +88,7 @@ void Jfr::on_klass_creation(InstanceKlass*& ik, ClassFileParser& parser, TRAPS) 
     JfrMethodTracer::on_klass_creation(ik, parser, THREAD);
   }
 }
+#endif
 
 void Jfr::on_klass_redefinition(const InstanceKlass* ik, Thread* thread) {
   assert(JfrMethodTracer::in_use(), "invariant");

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -60,7 +60,11 @@ class Jfr : AllStatic {
   static bool is_excluded(Thread* thread);
   static void include_thread(Thread* thread);
   static void exclude_thread(Thread* thread);
+#if HOTSPOT_TARGET_CLASSLIB == 8
+  static void on_klass_creation(InstanceKlass*& ik, ClassFileParser& parser, TRAPS) { }
+#else
   static void on_klass_creation(InstanceKlass*& ik, ClassFileParser& parser, TRAPS);
+#endif
   static void on_klass_redefinition(const InstanceKlass* ik, Thread* thread);
   static void on_thread_start(Thread* thread);
   static void on_thread_exit(Thread* thread);


### PR DESCRIPTION
The on_klass_creation event will use a native class transformer to do BCI, where some jdk25-only classes are involved thus causing `NoClassDefFoundError`. But this event is not supported in jdk8u, so this patch just disables it to fix the test failure.

------------------ summary ------------------
[baseline/#240] total=1321, passed=1304, failed=17, error=0
[newtest/#242] total=1321, passed=1305, failed=16, error=0
------------------ details ------------------
No new 'failed' tests
No new 'error' tests
------------------ end ------------------