### PR TITLE
altkernel: Align StackTraceElement fields with vm25

### DIFF
--- a/cvm/alt_kernel/src25u/java/lang/StackTraceElement.java
+++ b/cvm/alt_kernel/src25u/java/lang/StackTraceElement.java
@@ -40,6 +40,21 @@ import java.util.Objects;
  * @author Josh Bloch
  */
 public final class StackTraceElement implements java.io.Serializable {
+    private transient Class<?> declaringClassObject;
+
+    // Normally initialized by VM
+    /**
+     * @serial The name of the class loader.
+     */
+    private String classLoaderName;
+    /**
+     * @serial The module name.
+     */
+    private String moduleName;
+    /**
+     * @serial The module version.
+     */
+    private String moduleVersion;
     // Normally initialized by VM (public constructor added in 1.5)
     private String declaringClass;
     private String methodName;


### PR DESCRIPTION
which might cause memory corruption if unaligned

```
------------------ summary ------------------
[baseline/#242] total=1321, passed=1305, failed=16, error=0
[newtest/#245] total=1321, passed=1309, failed=12, error=0
------------------ details ------------------
No new 'failed' tests
No new 'error' tests
------------------ end ------------------
```