### PR TITLE
CI: run tests in parallel

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -302,7 +302,7 @@ ifeq ($(SKIP_BUILD), true)
 else
 -setup_jtreg8: $(JTREG) jdk8vm17
 endif
-	$(eval JT8_OPTS=-jdk:${CVM8DIR} -w:${JT8_WORKDIR} -r:${JT8_REPORTDIR} -a -ea -esa -ignore:quiet -ovm -v:fail,error,time -javaoption:-cvm ${JT8_OPTS})
+	$(eval JT8_OPTS=-jdk:${CVM8DIR} -w:${JT8_WORKDIR} -r:${JT8_REPORTDIR} -concurrency:auto -a -ea -esa -ignore:quiet -agentvm -v:fail,error,time -javaoption:-cvm ${JT8_OPTS})
 
 # Setup bootstrap JDK from a given URL
 # $1  root directory of jtreg


### PR DESCRIPTION
CI run time is reduced from 58min to 32min, compared to [previous run](https://github.com/bytedance/CompoundVM/actions/runs/24062091839). No additional failures introduced.