### PR TITLE
build: Use JDK8_JDK_SRC variable instead of wrong hardcoded path

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -145,9 +145,14 @@ $(BOOTJDK8)/:
 	$(call setup_boot_jdk,$(BOOTJDK8_URL),$@)
 	#cp -f $(WORKSPACE)/bin/linux-$(CVM_ARCH)/hsdis-$(ARCH_DIR).so $$(dirname $$(find $@ -name libjava.so))
 
-jdk8u/jdk/src:
-	wget -nc https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u452-ga.tar.gz
-	[[ -d $(JDK8_SRCROOT) ]] || (mkdir -p $(JDK8_SRCROOT) && tar -xzf jdk8u452-ga.tar.gz -C $(JDK8_SRCROOT) --strip-components=1)
+JDK8_JDK_SRC := $(JDK8_SRCROOT)/jdk/src
+JDK8_SRC_TAR_URL := https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u452-ga.tar.gz
+JDK8_SRC_TAR := $(notdir $(JDK8_SRC_TAR_URL))
+
+$(JDK8_JDK_SRC):
+	rm -f $(JDK8_SRC_TAR)
+	wget -nc -O $(JDK8_SRC_TAR) $(JDK8_SRC_TAR_URL)
+	[[ -d $(JDK8_SRCROOT) ]] || (mkdir -p $(JDK8_SRCROOT) && tar -xzf $(JDK8_SRC_TAR) -C $(JDK8_SRCROOT) --strip-components=1)
 
 cvm8: jdk8vm17
 
@@ -216,7 +221,7 @@ endif
 	@echo "###### Done ######"
 	@echo
 
-build_jdk8u: -bootstrap jdk8u/jdk/src
+build_jdk8u: -bootstrap $(JDK8_JDK_SRC)
 	{ cd $(JDK8_SRCROOT); \
 		if [[ "x$$(find ./build -type f -name config.log | grep $(MODE))" = "x" ]]; then \
 			bash configure --with-debug-level=$(MODE) \
@@ -298,7 +303,7 @@ $(JTREG):
 
 # minimize the effort to download source code
 ifeq ($(SKIP_BUILD), true)
--setup_jtreg8: -init-dirs $(JTREG) jdk8u/jdk/src
+-setup_jtreg8: -init-dirs $(JTREG) $(JDK8_JDK_SRC)
 else
 -setup_jtreg8: $(JTREG) jdk8vm17
 endif
@@ -388,10 +393,10 @@ help:
 	@echo "  make test_jtreg8 JT_TEST=<test selection> JT_REPO=<repo dir>"
 	@echo "                     Run CVM8 jtreg8 test with given selection"
 	@echo "  make test_jtreg8_jdk JT_TEST=<test selection>"
-	@echo "                     Run CVM8 jtreg8 tests in directory jdk8u/jdk/test"
+	@echo "                     Run CVM8 jtreg8 tests in directory $(CVM8_SRCROOT)/jdk/test"
 	@echo "  make test_jtreg8_langtools JT_TEST=<test selection>"
-	@echo "                     Run CVM8 jtreg8 tests in directory jdk8u/langtools/test"
+	@echo "                     Run CVM8 jtreg8 tests in directory $(CVM8_SRCROOT)/langtools/test"
 	@echo "  make test_jtreg8_hotspot JT_TEST=<test selection>"
-	@echo "                     Run CVM8 jtreg8 tests in directory jdk8u/hotspot/test"
+	@echo "                     Run CVM8 jtreg8 tests in directory $(CVM8_SRCROOT)/hotspot/test"
 	@echo "  make test_cvm8 JT_TEST=<test selection>"
 	@echo "                     Run additional jtreg8 tests for CVM8 in directory test"


### PR DESCRIPTION
## the problem
without this patch, try below commands in your workspace
```shell
rm -rf jdk8u452-ga.tar.gz
make -f cvm.mk cvm8 MODE=fastdebug
```
the script will try to download jdk8u452-ga-tar.gz even if cvm/jdk8u/jdk/src exists:
```shell
> make -f cvm.mk cvm8 MODE=fastdebug                                                  130 dev/fix_download_jdk8u_src!?
rm -fr /data00/home/luchuansheng/proj/CompoundVM/cvm/build/alt_kernel
rm -fr /data00/home/luchuansheng/proj/CompoundVM/cvm/build/jdk8
if [ "" = "1" ]; then \
        echo "Unsupported architecture! only x86_64 and aarch64 are supported."; \
        exit 1; \
fi
[[ -d /data00/home/luchuansheng/proj/CompoundVM/cvm/build ]] || mkdir -p /data00/home/luchuansheng/proj/CompoundVM/cvm/build
[[ -d /data00/home/luchuansheng/proj/CompoundVM/output ]] || mkdir -p /data00/home/luchuansheng/proj/CompoundVM/output
[[ -d /data00/home/luchuansheng/proj/CompoundVM/output/CompoundVM_8.17.3_linux_x64 ]] || mkdir -p /data00/home/luchuansheng/proj/CompoundVM/output/CompoundVM_8.17.3_linux_x64
[[ -d /data00/home/luchuansheng/proj/CompoundVM/output/CompoundVM_8.17.3_jvm_patch_linux_x64 ]] || mkdir -p /data00/home/luchuansheng/proj/CompoundVM/output/CompoundVM_8.17.3_jvm_patch_linux_x64
rm -f jdk8u452-ga.tar.gz
wget -nc -O jdk8u452-ga.tar.gz https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u452-ga.tar.gz
--2026-04-22 16:49:17--  https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u452-ga.tar.gz
Resolving sys-proxy-rd-relay.byted.org (sys-proxy-rd-relay.byted.org)... fdbd:dc02:fe:20a1::1, 10.8.6.103
Connecting to sys-proxy-rd-relay.byted.org (sys-proxy-rd-relay.byted.org)|fdbd:dc02:fe:20a1::1|:8118... connected.
Proxy request sent, awaiting response... 302 Found
Location: https://codeload.github.com/openjdk/jdk8u/tar.gz/refs/tags/jdk8u452-ga [following]
--2026-04-22 16:49:18--  https://codeload.github.com/openjdk/jdk8u/tar.gz/refs/tags/jdk8u452-ga
Connecting to sys-proxy-rd-relay.byted.org (sys-proxy-rd-relay.byted.org)|fdbd:dc02:fe:20a1::1|:8118... connected.
Proxy request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: ‘jdk8u452-ga.tar.gz’

jdk8u452-ga.tar.gz                          [                                                         <=>                  ]  88.50M  8.48MB/s    in 12s
```

## root cause
- wrong path `jdk8u/jdk/src` was set as target, will run `wget` anyway.
run `make -d ...` you will get:
```shell
Reaping winning child 0x5615bfeb8a50 PID 3209387
Removing child 0x5615bfeb8a50 PID 3209387 from chain.
      Successfully remade target file '-init-dirs'.
      Considering target file '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk-17.0.7+7/'.
       Finished prerequisites of target file '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk-17.0.7+7/'.
      No need to remake target '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk-17.0.7+7/'.
      Considering target file '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk8u372-b07/'.
       Finished prerequisites of target file '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk8u372-b07/'.
      No need to remake target '/data00/home/luchuansheng/proj/CompoundVM/.bootjdks/jdk8u372-b07/'.
     Finished prerequisites of target file '-bootstrap'.
    Must remake target '-bootstrap'.
    Successfully remade target file '-bootstrap'.
    Considering target file 'build_jdk8u'.
     File 'build_jdk8u' does not exist.
      Pruning file '-bootstrap'.
      Considering target file 'jdk8u/jdk/src'.
       File 'jdk8u/jdk/src' does not exist.
       Finished prerequisites of target file 'jdk8u/jdk/src'.
      Must remake target 'jdk8u/jdk/src'.
wget -nc https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u452-ga.tar.gz
Putting child 0x5615bfeb3910 (jdk8u/jdk/src) PID 3209388 on the chain.
Live child 0x5615bfeb3910 (jdk8u/jdk/src) PID 3209388
File ‘jdk8u452-ga.tar.gz’ already there; not retrieving.
```
- if jdk8u452-ga.tar.gz exists, `wget -nc` will skip downloading.