### PR TITLE
hotspot: Match VM options DIAGNOSTIC flag with classlib8

### DIFF
--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -2,13 +2,11 @@ compiler/6859338/Test6859338.java
 compiler/7196199/Test7196199.java
 compiler/8004741/Test8004741.java
 compiler/EscapeAnalysis/TestUnsafePutAddressNullObjMustNotEscape.java
-compiler/intrinsics/muladd/TestMulAdd.java
 compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
-compiler/intrinsics/squaretolen/TestSquareToLen.java
 compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
 compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
@@ -150,6 +148,4 @@ compiler/arguments/TestUseBMI1InstructionsOnUnsupportedCPU.java
 compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
 compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
 compiler/7184394/TestAESMain.java
-compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
-compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -2,13 +2,11 @@ compiler/6859338/Test6859338.java
 compiler/7196199/Test7196199.java
 compiler/8004741/Test8004741.java
 compiler/EscapeAnalysis/TestUnsafePutAddressNullObjMustNotEscape.java
-compiler/intrinsics/muladd/TestMulAdd.java
 compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
 compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
-compiler/intrinsics/squaretolen/TestSquareToLen.java
 compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
 compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
@@ -119,6 +117,7 @@ runtime/NMT/JcmdBaselineDetail.java
 runtime/NMT/JcmdDetailDiff.java
 runtime/NMT/JcmdSummaryDiff.java
 runtime/NMT/MallocSiteTypeChange.java
+runtime/NMT/MallocStressTest.java
 runtime/NMT/NMTWithCDS.java
 runtime/NMT/ShutdownTwice.java
 runtime/NMT/SummaryAfterShutdown.java
@@ -139,7 +138,6 @@ testlibrary_tests/whitebox/vm_flags/IntxTest.java
 testlibrary_tests/TestMutuallyExclusivePlatformPredicates.java
 vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
 
-compiler/intrinsics/montgomerymultiply/MontgomeryMultiplyTest.java
 compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -698,19 +698,19 @@
   product(bool, UseCharacterCompareIntrinsics, false, DIAGNOSTIC,           \
           "Enables intrinsification of java.lang.Character functions")      \
                                                                             \
-  product(bool, UseMultiplyToLenIntrinsic, false, DIAGNOSTIC,               \
+  product(bool, UseMultiplyToLenIntrinsic, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)                    \
           "Enables intrinsification of BigInteger.multiplyToLen()")         \
                                                                             \
-  product(bool, UseSquareToLenIntrinsic, false, DIAGNOSTIC,                 \
+  product(bool, UseSquareToLenIntrinsic, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)                      \
           "Enables intrinsification of BigInteger.squareToLen()")           \
                                                                             \
-  product(bool, UseMulAddIntrinsic, false, DIAGNOSTIC,                      \
+  product(bool, UseMulAddIntrinsic, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)                           \
           "Enables intrinsification of BigInteger.mulAdd()")                \
                                                                             \
-  product(bool, UseMontgomeryMultiplyIntrinsic, false, DIAGNOSTIC,          \
+  product(bool, UseMontgomeryMultiplyIntrinsic, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)               \
           "Enables intrinsification of BigInteger.montgomeryMultiply()")    \
                                                                             \
-  product(bool, UseMontgomerySquareIntrinsic, false, DIAGNOSTIC,            \
+  product(bool, UseMontgomerySquareIntrinsic, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)                 \
           "Enables intrinsification of BigInteger.montgomerySquare()")      \
                                                                             \
   product(bool, EnableVectorSupport, false, EXPERIMENTAL,                   \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -323,7 +323,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, CriticalJNINatives, false,                                  \
           "(Deprecated) Check for critical JNI entry points")               \
                                                                             \
-  product(bool, UseAESIntrinsics, false, DIAGNOSTIC,                        \
+  product(bool, UseAESIntrinsics, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,) \
           "Use intrinsics for AES versions of crypto")                      \
                                                                             \
   product(bool, UseAESCTRIntrinsics, false, DIAGNOSTIC,                     \
@@ -332,15 +332,15 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, UseMD5Intrinsics, false, DIAGNOSTIC,                        \
           "Use intrinsics for MD5 crypto hash function")                    \
                                                                             \
-  product(bool, UseSHA1Intrinsics, false, DIAGNOSTIC,                       \
+  product(bool, UseSHA1Intrinsics, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)      \
           "Use intrinsics for SHA-1 crypto hash function. "                 \
           "Requires that UseSHA is enabled.")                               \
                                                                             \
-  product(bool, UseSHA256Intrinsics, false, DIAGNOSTIC,                     \
+  product(bool, UseSHA256Intrinsics, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)    \
           "Use intrinsics for SHA-224 and SHA-256 crypto hash functions. "  \
           "Requires that UseSHA is enabled.")                               \
                                                                             \
-  product(bool, UseSHA512Intrinsics, false, DIAGNOSTIC,                     \
+  product(bool, UseSHA512Intrinsics, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)    \
           "Use intrinsics for SHA-384 and SHA-512 crypto hash functions. "  \
           "Requires that UseSHA is enabled.")                               \
                                                                             \
@@ -348,7 +348,7 @@ const intx ObjectAlignmentInBytes = 8;
           "Use intrinsics for SHA3 crypto hash function. "                  \
           "Requires that UseSHA is enabled.")                               \
                                                                             \
-  product(bool, UseCRC32Intrinsics, false, DIAGNOSTIC,                      \
+  product(bool, UseCRC32Intrinsics, false, CLASSLIB17_ONLY_FLAGS(DIAGNOSTIC,)     \
           "use intrinsics for java.util.zip.CRC32")                         \
                                                                             \
   product(bool, UseCRC32CIntrinsics, false, DIAGNOSTIC,                     \

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -643,6 +643,7 @@
   #define CLASSLIB17_ONLY(code)
   #define CLASSLIB8_EARLY_RETURN(ret) return ret
   #define CLASSLIB8_EARLY_RETURN_() return
+  #define CLASSLIB17_ONLY_FLAGS(...)
   #ifndef PRODUCT
     #define CLASSLIB8_DEBUG_ONLY(code) code
   #else
@@ -655,6 +656,7 @@
     #define CLASSLIB8_EARLY_RETURN(ret)
     #define CLASSLIB8_EARLY_RETURN_()
     #define CLASSLIB8_DEBUG_ONLY(code)
+    #define CLASSLIB17_ONLY_FLAGS(...) __VA_ARGS__
   #else
     #error("Unsupported class library version: " HOTSPOT_TARGET_CLASSLIB)
   #endif


### PR DESCRIPTION
Some options are changed from `product` to `diagnostic` after jdk8, which require additional command line argument. These options are changed back to `product`.

`runtime/NMT/MallocStressTest.java` is intermittent failure.