### PR TITLE
cvm/conf: Skip RTM cli tests on aarch64

### DIFF
--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -30,17 +30,6 @@ compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
 compiler/profiling/spectrapredefineclass/Launcher.java
 compiler/rangechecks/TestRangeCheckSmearing.java
-compiler/rtm/cli/TestPrintPreciseRTMLockingStatisticsOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestRTMAbortThresholdOption.java
-compiler/rtm/cli/TestRTMLockingCalculationDelayOption.java
-compiler/rtm/cli/TestRTMLockingThresholdOption.java
-compiler/rtm/cli/TestRTMRetryCountOption.java
-compiler/rtm/cli/TestRTMSpinLoopCountOption.java
-compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestUseRTMXendForLockBusyOption.java
 compiler/stable/TestStableBoolean.java
 compiler/stable/TestStableChar.java
 compiler/stable/TestStableByte.java
@@ -186,3 +175,16 @@ compiler/7184394/TestAESMain.java
 compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+
+# RTM cli options are not supported on aarch64. CVM for now ignores unknown options
+compiler/rtm/cli/TestPrintPreciseRTMLockingStatisticsOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestRTMAbortThresholdOption.java
+compiler/rtm/cli/TestRTMLockingCalculationDelayOption.java
+compiler/rtm/cli/TestRTMLockingThresholdOption.java
+compiler/rtm/cli/TestRTMRetryCountOption.java
+compiler/rtm/cli/TestRTMSpinLoopCountOption.java
+compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestUseRTMXendForLockBusyOption.java


### PR DESCRIPTION
RTM options are supported only on x86, and are unknown on aarch64. Tests fail because CVM now ignores unknown vm options. Skip for now