### PR TITLE
cvm/overlay: Fix NMethod test infra

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -439,6 +439,7 @@ endif
 	$(call overlay_single,jdk8u,hotspot/test/compiler/7196199/Test7196199.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/compiler/8004741/Test8004741.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/compiler/stable/StableConfiguration.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java, $(JDK8_SRCROOT))
 
 -overlay-jtreg:
 	$(call overlay_single,jdk8u,test/jtreg-ext/requires/VMProps.java, $(JDK8_SRCROOT))

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -20,14 +20,8 @@ compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMXendForLockBusyOption.java
 compiler/startup/NumCompilerThreadsCheck.java
-compiler/tiered/Level2RecompilationTest.java
-compiler/tiered/ConstantGettersTransitionsTest.java
 compiler/tiered/NonTieredLevelsTest.java
-compiler/tiered/TieredLevelsTest.java
 compiler/tiered/LevelTransitionTest.java
-compiler/whitebox/EnqueueMethodForCompilationTest.java
-compiler/whitebox/GetNMethodTest.java
-compiler/whitebox/MakeMethodNotCompilableTest.java
 gc/6941923/Test6941923.java
 gc/arguments/TestAggressiveHeap.java
 gc/arguments/TestG1ConcRefinementThreads.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -14,14 +14,8 @@ compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
 compiler/startup/NumCompilerThreadsCheck.java
-compiler/tiered/Level2RecompilationTest.java
-compiler/tiered/ConstantGettersTransitionsTest.java
 compiler/tiered/NonTieredLevelsTest.java
-compiler/tiered/TieredLevelsTest.java
 compiler/tiered/LevelTransitionTest.java
-compiler/whitebox/EnqueueMethodForCompilationTest.java
-compiler/whitebox/GetNMethodTest.java
-compiler/whitebox/MakeMethodNotCompilableTest.java
 gc/6941923/Test6941923.java
 gc/arguments/TestAggressiveHeap.java
 gc/arguments/TestG1ConcRefinementThreads.java

--- a/cvm/overlay/jdk8u/hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java
+++ b/cvm/overlay/jdk8u/hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.hotspot.code;
+
+import java.lang.reflect.Executable;
+import sun.hotspot.WhiteBox;
+
+public class NMethod {
+  private static final WhiteBox wb = WhiteBox.getWhiteBox();
+  public static NMethod get(Executable method, boolean isOsr) {
+    Object[] obj = wb.getNMethod(method, isOsr);
+    return obj == null ? null : new NMethod(obj);
+  }
+  private NMethod(Object[] obj) {
+    assert obj.length == 3;
+    comp_level = (Integer) obj[0];
+    compile_id = (Integer) obj[1];
+    insts = (byte[]) obj[2];
+  }
+  public final byte[] insts;
+  public final int comp_level;
+  public final int compile_id;
+
+  @Override
+  public String toString() {
+    return "NMethod{" +
+        "insts=" + insts +
+        ", comp_level=" + comp_level +
+        ", compile_id=" + compile_id +
+        '}';
+  }
+}

--- a/cvm/overlay/jdk8u/hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java
+++ b/cvm/overlay/jdk8u/hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java
@@ -34,21 +34,25 @@ public class NMethod {
     return obj == null ? null : new NMethod(obj);
   }
   private NMethod(Object[] obj) {
-    assert obj.length == 3;
-    comp_level = (Integer) obj[0];
-    compile_id = (Integer) obj[1];
+    assert obj.length == 5;
+    comp_level = (Integer) obj[1];
     insts = (byte[]) obj[2];
+    compile_id = (Integer) obj[3];
+    entry_point = (Long) obj[4];
   }
   public final byte[] insts;
   public final int comp_level;
   public final int compile_id;
+  public final long entry_point;
 
   @Override
   public String toString() {
-    return "NMethod{" +
-        "insts=" + insts +
-        ", comp_level=" + comp_level +
-        ", compile_id=" + compile_id +
-        '}';
+    return "NMethod{"
+        + super.toString()
+        + ", insts=" + insts
+        + ", comp_level=" + comp_level
+        + ", compile_id=" + compile_id
+        + ", entry_point=" + entry_point
+        + '}';
   }
 }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2471,9 +2471,9 @@ static JNINativeMethod methods[] = {
   {CC"isIntrinsicAvailable0",
       CC"(Ljava/lang/reflect/Executable;Ljava/lang/reflect/Executable;I)Z",
                                                       (void*)&WB_IsIntrinsicAvailable},
-  {CC"makeMethodNotCompilable0",
-      CC"(Ljava/lang/reflect/Executable;IZ)V",        (void*)&WB_MakeMethodNotCompilable},
 #if HOTSPOT_TARGET_CLASSLIB == 8
+  {CC"makeMethodNotCompilable",
+      CC"(Ljava/lang/reflect/Executable;IZ)V",        (void*)&WB_MakeMethodNotCompilable},
   {CC"testSetDontInlineMethod",
       CC"(Ljava/lang/reflect/Executable;Z)Z",         (void*)&WB_TestSetDontInlineMethod},
   {CC"getMethodCompilationLevel",
@@ -2483,6 +2483,8 @@ static JNINativeMethod methods[] = {
   {CC"testSetForceInlineMethod",
       CC"(Ljava/lang/reflect/Executable;Z)Z",         (void*)&WB_TestSetForceInlineMethod},
 #elif HOTSPOT_TARGET_CLASSLIB == 17
+  {CC"makeMethodNotCompilable0",
+      CC"(Ljava/lang/reflect/Executable;IZ)V",        (void*)&WB_MakeMethodNotCompilable},
   {CC"testSetDontInlineMethod0",
       CC"(Ljava/lang/reflect/Executable;Z)Z",         (void*)&WB_TestSetDontInlineMethod},
   {CC"getMethodCompilationLevel0",


### PR DESCRIPTION
`Whitebox.getNMethod` now returns a different array structure.