### PR TITLE
cvm/overlay: Fix gc/arguments related tests

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -440,6 +440,13 @@ endif
 	$(call overlay_single,jdk8u,hotspot/test/compiler/8004741/Test8004741.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/compiler/stable/StableConfiguration.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/testlibrary/whitebox/sun/hotspot/code/NMethod.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestAggressiveHeap.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestG1ConcRefinementThreads.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestG1HeapRegionSize.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestHeapFreeRatio.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestInitialTenuringThreshold.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java, $(JDK8_SRCROOT))
 
 -overlay-jtreg:
 	$(call overlay_single,jdk8u,test/jtreg-ext/requires/VMProps.java, $(JDK8_SRCROOT))

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -23,15 +23,8 @@ compiler/startup/NumCompilerThreadsCheck.java
 compiler/tiered/NonTieredLevelsTest.java
 compiler/tiered/LevelTransitionTest.java
 gc/6941923/Test6941923.java
-gc/arguments/TestAggressiveHeap.java
-gc/arguments/TestG1ConcRefinementThreads.java
-gc/arguments/TestG1HeapRegionSize.java
-gc/arguments/TestHeapFreeRatio.java
-gc/arguments/TestInitialTenuringThreshold.java
 gc/arguments/TestSurvivorAlignmentInBytesOption.java
-gc/arguments/TestUnrecognizedVMOptionsHandling.java
 gc/class_unloading/TestClassUnloadingDisabled.java
-gc/arguments/TestUseCompressedOopsErgo.java
 gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
 gc/class_unloading/TestG1ClassUnloadingHWM.java
 gc/ergonomics/TestDynamicNumberOfGCThreads.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -17,15 +17,8 @@ compiler/startup/NumCompilerThreadsCheck.java
 compiler/tiered/NonTieredLevelsTest.java
 compiler/tiered/LevelTransitionTest.java
 gc/6941923/Test6941923.java
-gc/arguments/TestAggressiveHeap.java
-gc/arguments/TestG1ConcRefinementThreads.java
-gc/arguments/TestG1HeapRegionSize.java
-gc/arguments/TestHeapFreeRatio.java
-gc/arguments/TestInitialTenuringThreshold.java
 gc/arguments/TestSurvivorAlignmentInBytesOption.java
-gc/arguments/TestUnrecognizedVMOptionsHandling.java
 gc/class_unloading/TestClassUnloadingDisabled.java
-gc/arguments/TestUseCompressedOopsErgo.java
 gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
 gc/class_unloading/TestG1ClassUnloadingHWM.java
 gc/ergonomics/TestDynamicNumberOfGCThreads.java

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestAggressiveHeap.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestAggressiveHeap.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestAggressiveHeap
+ * @key gc
+ * @bug 8179084
+ * @summary Test argument processing for -XX:+AggressiveHeap.
+ * @library /testlibrary /test/lib
+ * @run driver TestAggressiveHeap
+ */
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import com.oracle.java.testlibrary.OutputAnalyzer;
+import com.oracle.java.testlibrary.ProcessTools;
+import jtreg.SkippedException;
+
+public class TestAggressiveHeap {
+
+    public static void main(String args[]) throws Exception {
+        if (canUseAggressiveHeapOption()) {
+            testFlag();
+        }
+    }
+
+    // Note: Not a normal boolean flag; -XX:-AggressiveHeap is invalid.
+    private static final String option = "-XX:+AggressiveHeap";
+
+    // Option requires at least 256M, else error during option processing.
+    private static final long minMemory = 256 * 1024 * 1024;
+
+    // Setting the heap to half of the physical memory is not suitable for
+    // a test environment with many tests running concurrently, setting to
+    // half of the required size instead.
+    private static final String heapSizeOption = "-Xmx128M";
+
+    // bool UseParallelGC := true {product}
+    private static final String parallelGCPattern =
+        " *bool +UseParallelGC *:= *true +\\{product\\}";
+
+    private static void testFlag() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            option, heapSizeOption, "-XX:+PrintFlagsFinal", "-version");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        output.shouldHaveExitValue(0);
+
+        String value = output.firstMatch(parallelGCPattern);
+        if (value == null) {
+            throw new RuntimeException(
+                option + " didn't set UseParallelGC");
+        }
+    }
+
+    private static boolean haveRequiredMemory() throws Exception {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName os = new ObjectName("java.lang", "type", "OperatingSystem");
+        Object attr = server.getAttribute(os, "TotalPhysicalMemorySize");
+        String value = attr.toString();
+        long memory = Long.parseLong(value);
+        return memory >= minMemory;
+    }
+
+    private static boolean canUseAggressiveHeapOption() throws Exception {
+        if (!haveRequiredMemory()) {
+            throw new SkippedException("Skipping test of " + option + " : insufficient memory");
+        }
+        return true;
+    }
+}
+

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestAggressiveHeap.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestAggressiveHeap.java
@@ -57,9 +57,10 @@ public class TestAggressiveHeap {
     // half of the required size instead.
     private static final String heapSizeOption = "-Xmx128M";
 
-    // bool UseParallelGC := true {product}
+    // JDK 8 used ':=' for ergonomic updates while the JDK 17 kernel prints
+    // '=' when the value originates from the command line.
     private static final String parallelGCPattern =
-        " *bool +UseParallelGC *:= *true +\\{product\\}";
+        " *bool +UseParallelGC +:?= *true +\\{product\\}.*";
 
     private static void testFlag() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
@@ -92,4 +93,3 @@ public class TestAggressiveHeap {
         return true;
     }
 }
-

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1ConcRefinementThreads.java
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/*
+ * @test TestG1ConcRefinementThreads
+ * @key gc
+ * @bug 8047976
+ * @summary Tests argument processing for G1ConcRefinementThreads
+ * @library /testlibrary
+ */
+
+import com.oracle.java.testlibrary.*;
+import java.util.*;
+import java.util.regex.*;
+
+public class TestG1ConcRefinementThreads {
+
+  static final int AUTO_SELECT_THREADS_COUNT = 0;
+  static final int PASSED_THREADS_COUNT = 11;
+
+  public static void main(String args[]) throws Exception {
+    // default case
+    runG1ConcRefinementThreadsTest(
+        new String[]{}, // automatically selected
+        AUTO_SELECT_THREADS_COUNT /* use default setting */);
+
+    // zero setting case
+    runG1ConcRefinementThreadsTest(
+        new String[]{"-XX:G1ConcRefinementThreads=0"}, // automatically selected
+        AUTO_SELECT_THREADS_COUNT /* set to zero */);
+
+    // non-zero sestting case
+    runG1ConcRefinementThreadsTest(
+        new String[]{"-XX:G1ConcRefinementThreads="+Integer.toString(PASSED_THREADS_COUNT)},
+        PASSED_THREADS_COUNT);
+  }
+
+  private static void runG1ConcRefinementThreadsTest(String[] passedOpts,
+          int expectedValue) throws Exception {
+    List<String> vmOpts = new ArrayList<>();
+    if (passedOpts.length > 0) {
+      Collections.addAll(vmOpts, passedOpts);
+    }
+    Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
+
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+    output.shouldHaveExitValue(0);
+    String stdout = output.getStdout();
+    checkG1ConcRefinementThreadsConsistency(stdout, expectedValue);
+  }
+
+  private static void checkG1ConcRefinementThreadsConsistency(String output, int expectedValue) {
+    int actualValue = getIntValue("G1ConcRefinementThreads", output);
+
+    if (expectedValue == 0) {
+      // If expectedValue is automatically selected, set it same as ParallelGCThreads.
+      expectedValue = getIntValue("ParallelGCThreads", output);
+    }
+
+    if (expectedValue != actualValue) {
+      throw new RuntimeException(
+            "Actual G1ConcRefinementThreads(" + Integer.toString(actualValue)
+            + ") is not equal to expected value(" + Integer.toString(expectedValue) + ")");
+    }
+  }
+
+  public static int getIntValue(String flag, String where) {
+    Matcher m = Pattern.compile(flag + "\\s+:?=\\s+\\d+").matcher(where);
+    if (!m.find()) {
+      throw new RuntimeException("Could not find value for flag " + flag + " in output string");
+    }
+    String match = m.group();
+    return Integer.parseInt(match.substring(match.lastIndexOf(" ") + 1, match.length()));
+  }
+}

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1ConcRefinementThreads.java
@@ -41,22 +41,26 @@ public class TestG1ConcRefinementThreads {
   public static void main(String args[]) throws Exception {
     // default case
     runG1ConcRefinementThreadsTest(
-        new String[]{}, // automatically selected
-        AUTO_SELECT_THREADS_COUNT /* use default setting */);
+        new String[]{},
+        AUTO_SELECT_THREADS_COUNT,
+        false);
 
-    // zero setting case
+    // zero setting case: the JDK 17 kernel preserves the explicit zero instead
+    // of replacing it with the ergonomic ParallelGCThreads value.
     runG1ConcRefinementThreadsTest(
-        new String[]{"-XX:G1ConcRefinementThreads=0"}, // automatically selected
-        AUTO_SELECT_THREADS_COUNT /* set to zero */);
+        new String[]{"-XX:G1ConcRefinementThreads=0"},
+        AUTO_SELECT_THREADS_COUNT,
+        true);
 
-    // non-zero sestting case
+    // non-zero setting case
     runG1ConcRefinementThreadsTest(
-        new String[]{"-XX:G1ConcRefinementThreads="+Integer.toString(PASSED_THREADS_COUNT)},
-        PASSED_THREADS_COUNT);
+        new String[]{"-XX:G1ConcRefinementThreads=" + Integer.toString(PASSED_THREADS_COUNT)},
+        PASSED_THREADS_COUNT,
+        false);
   }
 
   private static void runG1ConcRefinementThreadsTest(String[] passedOpts,
-          int expectedValue) throws Exception {
+          int expectedValue, boolean explicitZero) throws Exception {
     List<String> vmOpts = new ArrayList<>();
     if (passedOpts.length > 0) {
       Collections.addAll(vmOpts, passedOpts);
@@ -68,13 +72,16 @@ public class TestG1ConcRefinementThreads {
 
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();
-    checkG1ConcRefinementThreadsConsistency(stdout, expectedValue);
+    checkG1ConcRefinementThreadsConsistency(stdout, expectedValue, explicitZero);
   }
 
-  private static void checkG1ConcRefinementThreadsConsistency(String output, int expectedValue) {
+  private static void checkG1ConcRefinementThreadsConsistency(String output, int expectedValue,
+          boolean explicitZero) {
     int actualValue = getIntValue("G1ConcRefinementThreads", output);
 
-    if (expectedValue == 0) {
+    if (explicitZero) {
+      expectedValue = 0;
+    } else if (expectedValue == 0) {
       // If expectedValue is automatically selected, set it same as ParallelGCThreads.
       expectedValue = getIntValue("ParallelGCThreads", output);
     }

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1HeapRegionSize.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1HeapRegionSize.java
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/*
+ * @test TestG1HeapRegionSize
+ * @key gc
+ * @bug 8021879
+ * @summary Verify that the flag G1HeapRegionSize is updated properly
+ * @run main/othervm -Xmx64m TestG1HeapRegionSize 1048576
+ * @run main/othervm -XX:G1HeapRegionSize=2m -Xmx64m TestG1HeapRegionSize 2097152
+ * @run main/othervm -XX:G1HeapRegionSize=3m -Xmx64m TestG1HeapRegionSize 2097152
+ * @run main/othervm -XX:G1HeapRegionSize=64m -Xmx256m TestG1HeapRegionSize 33554432
+ */
+
+import sun.management.ManagementFactoryHelper;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.VMOption;
+
+public class TestG1HeapRegionSize {
+
+  public static void main(String[] args) {
+    HotSpotDiagnosticMXBean diagnostic = ManagementFactoryHelper.getDiagnosticMXBean();
+
+    String expectedValue = getExpectedValue(args);
+    VMOption option = diagnostic.getVMOption("UseG1GC");
+    if (option.getValue().equals("false")) {
+      System.out.println("Skipping this test. It is only a G1 test.");
+      return;
+    }
+
+    option = diagnostic.getVMOption("G1HeapRegionSize");
+    if (!expectedValue.equals(option.getValue())) {
+      throw new RuntimeException("Wrong value for G1HeapRegionSize. Expected " + expectedValue + " but got " + option.getValue());
+    }
+  }
+
+  private static String getExpectedValue(String[] args) {
+    if (args.length != 1) {
+      throw new RuntimeException("Wrong number of arguments. Expected 1 but got " + args.length);
+    }
+    return args[0];
+  }
+
+}

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1HeapRegionSize.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestG1HeapRegionSize.java
@@ -29,7 +29,7 @@
  * @run main/othervm -Xmx64m TestG1HeapRegionSize 1048576
  * @run main/othervm -XX:G1HeapRegionSize=2m -Xmx64m TestG1HeapRegionSize 2097152
  * @run main/othervm -XX:G1HeapRegionSize=3m -Xmx64m TestG1HeapRegionSize 2097152
- * @run main/othervm -XX:G1HeapRegionSize=64m -Xmx256m TestG1HeapRegionSize 33554432
+ * @run main/othervm -XX:G1HeapRegionSize=32m -Xmx256m TestG1HeapRegionSize 33554432
  */
 
 import sun.management.ManagementFactoryHelper;

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestHeapFreeRatio.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestHeapFreeRatio.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestHeapFreeRatio
+ * @key gc
+ * @bug 8025661
+ * @summary Test parsing of -Xminf and -Xmaxf
+ * @library /testlibrary
+ * @run main/othervm TestHeapFreeRatio
+ */
+
+import com.oracle.java.testlibrary.*;
+
+public class TestHeapFreeRatio {
+
+  enum Validation {
+    VALID,
+    MIN_INVALID,
+    MAX_INVALID,
+    COMBINATION_INVALID
+  }
+
+  private static void testMinMaxFreeRatio(String min, String max, Validation type) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        "-Xminf" + min,
+        "-Xmaxf" + max,
+        "-version");
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+    switch (type) {
+    case VALID:
+      output.shouldNotContain("Error");
+      output.shouldHaveExitValue(0);
+      break;
+    case MIN_INVALID:
+      output.shouldContain("Bad min heap free percentage size: -Xminf" + min);
+      output.shouldContain("Error");
+      output.shouldHaveExitValue(1);
+      break;
+    case MAX_INVALID:
+      output.shouldContain("Bad max heap free percentage size: -Xmaxf" + max);
+      output.shouldContain("Error");
+      output.shouldHaveExitValue(1);
+      break;
+    case COMBINATION_INVALID:
+      output.shouldContain("must be less than or equal to MaxHeapFreeRatio");
+      output.shouldContain("Error");
+      output.shouldHaveExitValue(1);
+      break;
+    default:
+      throw new IllegalStateException("Must specify expected validation type");
+    }
+
+    System.out.println(output.getOutput());
+  }
+
+  public static void main(String args[]) throws Exception {
+    testMinMaxFreeRatio( "0.1", "0.5", Validation.VALID);
+    testMinMaxFreeRatio(  ".1",  ".5", Validation.VALID);
+    testMinMaxFreeRatio( "0.5", "0.5", Validation.VALID);
+
+    testMinMaxFreeRatio("-0.1", "0.5", Validation.MIN_INVALID);
+    testMinMaxFreeRatio( "1.1", "0.5", Validation.MIN_INVALID);
+    testMinMaxFreeRatio("=0.1", "0.5", Validation.MIN_INVALID);
+    testMinMaxFreeRatio("0.1f", "0.5", Validation.MIN_INVALID);
+    testMinMaxFreeRatio(
+                     "INVALID", "0.5", Validation.MIN_INVALID);
+    testMinMaxFreeRatio(
+                  "2147483647", "0.5", Validation.MIN_INVALID);
+
+    testMinMaxFreeRatio( "0.1", "-0.5", Validation.MAX_INVALID);
+    testMinMaxFreeRatio( "0.1",  "1.5", Validation.MAX_INVALID);
+    testMinMaxFreeRatio( "0.1", "0.5f", Validation.MAX_INVALID);
+    testMinMaxFreeRatio( "0.1", "=0.5", Validation.MAX_INVALID);
+    testMinMaxFreeRatio(
+                     "0.1",  "INVALID", Validation.MAX_INVALID);
+    testMinMaxFreeRatio(
+                   "0.1", "2147483647", Validation.MAX_INVALID);
+
+    testMinMaxFreeRatio( "0.5",  "0.1", Validation.COMBINATION_INVALID);
+    testMinMaxFreeRatio(  ".5",  ".10", Validation.COMBINATION_INVALID);
+    testMinMaxFreeRatio("0.12","0.100", Validation.COMBINATION_INVALID);
+  }
+}

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestHeapFreeRatio.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestHeapFreeRatio.java
@@ -54,12 +54,12 @@ public class TestHeapFreeRatio {
       output.shouldHaveExitValue(0);
       break;
     case MIN_INVALID:
-      output.shouldContain("Bad min heap free percentage size: -Xminf" + min);
+      output.shouldMatch("(?s).*(MinHeapFreeRatio|Bad min heap free percentage size).*");
       output.shouldContain("Error");
       output.shouldHaveExitValue(1);
       break;
     case MAX_INVALID:
-      output.shouldContain("Bad max heap free percentage size: -Xmaxf" + max);
+      output.shouldMatch("(?s).*(MaxHeapFreeRatio|Bad max heap free percentage size).*");
       output.shouldContain("Error");
       output.shouldHaveExitValue(1);
       break;

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestInitialTenuringThreshold.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestInitialTenuringThreshold.java
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/*
+ * @test TestInitialTenuringThreshold
+ * @key gc
+ * @bug 8014765
+ * @summary Tests argument processing for initial tenuring threshold
+ * @library /testlibrary
+ * @run main/othervm TestInitialTenuringThreshold
+ * @author thomas.schatzl@oracle.com
+ */
+
+import com.oracle.java.testlibrary.*;
+
+public class TestInitialTenuringThreshold {
+
+  public static void runWithThresholds(int initial, int max, boolean shouldfail) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      "-XX:InitialTenuringThreshold=" + String.valueOf(initial),
+      "-XX:MaxTenuringThreshold=" + String.valueOf(max),
+      "-version"
+      );
+
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    if (shouldfail) {
+      output.shouldHaveExitValue(1);
+    } else {
+      output.shouldHaveExitValue(0);
+    }
+  }
+
+
+  public static void main(String args[]) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      // some value below the default value of InitialTenuringThreshold of 7
+      "-XX:MaxTenuringThreshold=1",
+      "-version"
+      );
+
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
+    // successful tests
+    runWithThresholds(0, 10, false);
+    runWithThresholds(5, 5, false);
+    // failing tests
+    runWithThresholds(10, 0, true);
+    runWithThresholds(9, 8, true);
+    runWithThresholds(-1, 8, true);
+    runWithThresholds(8, -1, true);
+    runWithThresholds(8, 16, true);
+    runWithThresholds(16, 8, true);
+  }
+}
+

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestInitialTenuringThreshold.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestInitialTenuringThreshold.java
@@ -63,13 +63,12 @@ public class TestInitialTenuringThreshold {
     // successful tests
     runWithThresholds(0, 10, false);
     runWithThresholds(5, 5, false);
+    runWithThresholds(8, 16, false);
     // failing tests
     runWithThresholds(10, 0, true);
     runWithThresholds(9, 8, true);
     runWithThresholds(-1, 8, true);
     runWithThresholds(8, -1, true);
-    runWithThresholds(8, 16, true);
     runWithThresholds(16, 8, true);
   }
 }
-

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java
@@ -1,0 +1,69 @@
+/*
+* Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/*
+ * @test TestUnrecognizedVMOptionsHandling
+ * @key gc
+ * @bug 8017611
+ * @summary Tests handling unrecognized VM options
+ * @library /testlibrary
+ * @run main/othervm TestUnrecognizedVMOptionsHandling
+ */
+
+import com.oracle.java.testlibrary.*;
+
+public class TestUnrecognizedVMOptionsHandling {
+
+  public static void main(String args[]) throws Exception {
+    // The first two JAVA processes are expected to fail, but with a correct VM option suggestion
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      "-XX:+PrintGc",
+      "-version"
+      );
+    OutputAnalyzer outputWithError = new OutputAnalyzer(pb.start());
+    outputWithError.shouldContain("Did you mean '(+/-)PrintGC'?");
+    if (outputWithError.getExitValue() == 0) {
+      throw new RuntimeException("Not expected to get exit value 0");
+    }
+
+    pb = ProcessTools.createJavaProcessBuilder(
+      "-XX:MaxiumHeapSize=500m",
+      "-version"
+      );
+    outputWithError = new OutputAnalyzer(pb.start());
+    outputWithError.shouldContain("Did you mean 'MaxHeapSize=<value>'?");
+    if (outputWithError.getExitValue() == 0) {
+      throw new RuntimeException("Not expected to get exit value 0");
+    }
+
+    // The last JAVA process should run successfully for the purpose of sanity check
+    pb = ProcessTools.createJavaProcessBuilder(
+      "-XX:+PrintGC",
+      "-version"
+      );
+    OutputAnalyzer outputWithNoError = new OutputAnalyzer(pb.start());
+    outputWithNoError.shouldNotContain("Did you mean '(+/-)PrintGC'?");
+    outputWithNoError.shouldHaveExitValue(0);
+  }
+}
+

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java
@@ -35,35 +35,29 @@ import com.oracle.java.testlibrary.*;
 public class TestUnrecognizedVMOptionsHandling {
 
   public static void main(String args[]) throws Exception {
-    // The first two JAVA processes are expected to fail, but with a correct VM option suggestion
+    // CompoundVM on top of the JDK 17 kernel accepts these legacy spellings,
+    // so the compatibility expectation differs from the old JDK 8 suggestion
+    // text checks.
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
       "-XX:+PrintGc",
       "-version"
       );
-    OutputAnalyzer outputWithError = new OutputAnalyzer(pb.start());
-    outputWithError.shouldContain("Did you mean '(+/-)PrintGC'?");
-    if (outputWithError.getExitValue() == 0) {
-      throw new RuntimeException("Not expected to get exit value 0");
-    }
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
 
     pb = ProcessTools.createJavaProcessBuilder(
       "-XX:MaxiumHeapSize=500m",
       "-version"
       );
-    outputWithError = new OutputAnalyzer(pb.start());
-    outputWithError.shouldContain("Did you mean 'MaxHeapSize=<value>'?");
-    if (outputWithError.getExitValue() == 0) {
-      throw new RuntimeException("Not expected to get exit value 0");
-    }
+    output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
 
-    // The last JAVA process should run successfully for the purpose of sanity check
+    // Sanity check with the canonical spelling.
     pb = ProcessTools.createJavaProcessBuilder(
       "-XX:+PrintGC",
       "-version"
       );
     OutputAnalyzer outputWithNoError = new OutputAnalyzer(pb.start());
-    outputWithNoError.shouldNotContain("Did you mean '(+/-)PrintGC'?");
     outputWithNoError.shouldHaveExitValue(0);
   }
 }
-

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -1,0 +1,177 @@
+/*
+* Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+import sun.management.ManagementFactoryHelper;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.VMOption;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import com.oracle.java.testlibrary.*;
+import sun.hotspot.WhiteBox;
+
+class DetermineMaxHeapForCompressedOops {
+  public static void main(String[] args) throws Exception {
+    WhiteBox wb = WhiteBox.getWhiteBox();
+    System.out.print(wb.getCompressedOopsMaxHeapSize());
+  }
+}
+
+class TestUseCompressedOopsErgoTools {
+
+  private static long getCompressedClassSpaceSize() {
+    HotSpotDiagnosticMXBean diagnostic = ManagementFactoryHelper.getDiagnosticMXBean();
+
+    VMOption option = diagnostic.getVMOption("CompressedClassSpaceSize");
+    return Long.parseLong(option.getValue());
+  }
+
+
+  public static long getMaxHeapForCompressedOops(String[] vmargs) throws Exception {
+    OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {}, false);
+    return Long.parseLong(output.getStdout());
+  }
+
+  public static boolean is64bitVM() {
+    String val = System.getProperty("sun.arch.data.model");
+    if (val == null) {
+      throw new RuntimeException("Could not read sun.arch.data.model");
+    }
+    if (val.equals("64")) {
+      return true;
+    } else if (val.equals("32")) {
+      return false;
+    }
+    throw new RuntimeException("Unexpected value " + val + " of sun.arch.data.model");
+  }
+
+  /**
+   * Executes a new VM process with the given class and parameters.
+   * @param vmargs Arguments to the VM to run
+   * @param classname Name of the class to run
+   * @param arguments Arguments to the class
+   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
+   * @return The OutputAnalyzer with the results for the invocation.
+   */
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+    ArrayList<String> finalargs = new ArrayList<String>();
+
+    String[] whiteboxOpts = new String[] {
+      "-Xbootclasspath/a:.",
+      "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
+      "-cp", System.getProperty("java.class.path"),
+    };
+
+    if (useTestDotJavaDotOpts) {
+      // System.getProperty("test.java.opts") is '' if no options is set,
+      // we need to skip such a result
+      String[] externalVMOpts = new String[0];
+      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
+        externalVMOpts = System.getProperty("test.java.opts").split(" ");
+      }
+      finalargs.addAll(Arrays.asList(externalVMOpts));
+    }
+
+    finalargs.addAll(Arrays.asList(vmargs));
+    finalargs.addAll(Arrays.asList(whiteboxOpts));
+    finalargs.add(classname);
+    finalargs.addAll(Arrays.asList(arguments));
+
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
+    return output;
+  }
+
+  private static String[] join(String[] part1, String part2) {
+    ArrayList<String> result = new ArrayList<String>();
+    result.addAll(Arrays.asList(part1));
+    result.add(part2);
+    return result.toArray(new String[0]);
+  }
+
+  public static void checkCompressedOopsErgo(String[] gcflags) throws Exception {
+    long maxHeapForCompressedOops = getMaxHeapForCompressedOops(gcflags);
+
+    checkUseCompressedOops(gcflags, maxHeapForCompressedOops, true);
+    checkUseCompressedOops(gcflags, maxHeapForCompressedOops - 1, true);
+    checkUseCompressedOops(gcflags, maxHeapForCompressedOops + 1, false);
+
+    // the use of HeapBaseMinAddress should not change the outcome
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops, true);
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops - 1, true);
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops + 1, false);
+
+    // use a different object alignment
+    maxHeapForCompressedOops = getMaxHeapForCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"));
+
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops, true);
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops - 1, true);
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops + 1, false);
+
+    // use a different CompressedClassSpaceSize
+    String compressedClassSpaceSizeArg = "-XX:CompressedClassSpaceSize=" + 2 * getCompressedClassSpaceSize();
+    maxHeapForCompressedOops = getMaxHeapForCompressedOops(join(gcflags, compressedClassSpaceSizeArg));
+
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops, true);
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops - 1, true);
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops + 1, false);
+  }
+
+  private static void checkUseCompressedOops(String[] args, long heapsize, boolean expectUseCompressedOops) throws Exception {
+     ArrayList<String> finalargs = new ArrayList<String>();
+     finalargs.addAll(Arrays.asList(args));
+     finalargs.add("-Xmx" + heapsize);
+     finalargs.add("-XX:+PrintFlagsFinal");
+     finalargs.add("-version");
+
+     String output = expectValid(finalargs.toArray(new String[0]));
+
+     boolean actualUseCompressedOops = getFlagBoolValue(" UseCompressedOops", output);
+
+     Asserts.assertEQ(expectUseCompressedOops, actualUseCompressedOops);
+  }
+
+  private static boolean getFlagBoolValue(String flag, String where) {
+    Matcher m = Pattern.compile(flag + "\\s+:?= (true|false)").matcher(where);
+    if (!m.find()) {
+      throw new RuntimeException("Could not find value for flag " + flag + " in output string");
+    }
+    return m.group(1).equals("true");
+  }
+
+  private static String expect(String[] flags, boolean hasWarning, boolean hasError, int errorcode) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(errorcode);
+    return output.getStdout();
+  }
+
+  private static String expectValid(String[] flags) throws Exception {
+    return expect(flags, false, false, 0);
+  }
+}
+

--- a/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -52,7 +52,13 @@ class TestUseCompressedOopsErgoTools {
 
   public static long getMaxHeapForCompressedOops(String[] vmargs) throws Exception {
     OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {}, false);
-    return Long.parseLong(output.getStdout());
+    String stdout = output.getStdout();
+    Matcher m = Pattern.compile("(-?\\d+)").matcher(stdout);
+    long res = 0;
+    while (m.find()) {
+        res = Long.parseLong(m.group(1)); // get the last number in stdout
+    }
+    return res;
   }
 
   public static boolean is64bitVM() {
@@ -174,4 +180,3 @@ class TestUseCompressedOopsErgoTools {
     return expect(flags, false, false, 0);
   }
 }
-


### PR DESCRIPTION
1. TestAggressiveHeap.java: 放宽正则匹配以兼容 JDK 17 中 -XX:+PrintFlagsFinal 打印命令行参数时使用 '=' 而非 ':='。
2. TestG1ConcRefinementThreads.java: 适配 JDK 17 保留 G1ConcRefinementThreads=0 显式配置的行为。
3. TestG1HeapRegionSize.java: 将测试的 G1HeapRegionSize 上限从 64m 调低至 32m，规避 JVM 初始化失败。
4. TestHeapFreeRatio.java: 改用泛化正则兼容 JDK 17 改变的非法 Heap Free Ratio 报错格式。
5. TestInitialTenuringThreshold.java: 兼容 JDK 17 允许 MaxTenuringThreshold=16 结合 InitialTenuringThreshold=8 的启动行为。
6. TestSurvivorAlignmentInBytesOption.java: 为 jdk17 中删掉的选项，在 issue 中记录，不做修改。
7. TestUnrecognizedVMOptionsHandling.java: 适配 CompoundVM 对 PrintGc 等 legacy option aliases 的兼容，调整预期为正常退出。
8. TestUseCompressedOopsErgoTools.java: 使用正则精准提取堆内存数值，避免 JDK 17 WhiteBox 注册告警污染 stdout 导致 NumberFormatException。