### PR TITLE
cvm/overlay: Fix gc/startup_warnings tests

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -448,6 +448,7 @@ endif
 	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestUnrecognizedVMOptionsHandling.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/testlibrary/whitebox/sun/hotspot/WhiteBox.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java, $(JDK8_SRCROOT))
 
 -overlay-jtreg:
 	$(call overlay_single,jdk8u,test/jtreg-ext/requires/VMProps.java, $(JDK8_SRCROOT))

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -45,7 +45,6 @@ gc/metaspace/TestMetaspaceSizeFlags.java
 gc/parallelScavenge/AdaptiveGCBoundary.java
 gc/startup_warnings/TestCMSForegroundFlags.java
 gc/startup_warnings/TestCMSIncrementalMode.java
-gc/startup_warnings/TestDefaultMaxRAMFraction.java
 gc/startup_warnings/TestDefNewCMS.java
 gc/startup_warnings/TestIncGC.java
 gc/6581734/Test6581734.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -39,7 +39,6 @@ gc/metaspace/TestMetaspaceSizeFlags.java
 gc/parallelScavenge/AdaptiveGCBoundary.java
 gc/startup_warnings/TestCMSForegroundFlags.java
 gc/startup_warnings/TestCMSIncrementalMode.java
-gc/startup_warnings/TestDefaultMaxRAMFraction.java
 gc/startup_warnings/TestDefNewCMS.java
 gc/startup_warnings/TestIncGC.java
 gc/6581734/Test6581734.java

--- a/cvm/overlay/jdk8u/hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/*
+* @test TestDefaultMaxRAMFraction
+* @key gc
+* @bug 8021967
+* @summary Test that the deprecated TestDefaultMaxRAMFraction flag print a warning message
+* @library /testlibrary
+*/
+
+import com.oracle.java.testlibrary.OutputAnalyzer;
+import com.oracle.java.testlibrary.ProcessTools;
+
+public class TestDefaultMaxRAMFraction {
+  public static void main(String[] args) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:DefaultMaxRAMFraction=4", "-version");
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldContain("warning: DefaultMaxRAMFraction is deprecated and will likely be removed in a future release. Use MaxRAMFraction instead.");
+    output.shouldNotContain("error");
+    output.shouldHaveExitValue(0);
+  }
+
+}

--- a/cvm/overlay/jdk8u/hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java
+++ b/cvm/overlay/jdk8u/hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java
@@ -36,7 +36,7 @@ public class TestDefaultMaxRAMFraction {
   public static void main(String[] args) throws Exception {
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:DefaultMaxRAMFraction=4", "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldContain("warning: DefaultMaxRAMFraction is deprecated and will likely be removed in a future release. Use MaxRAMFraction instead.");
+    output.shouldContain("warning: Option DefaultMaxRAMFraction was deprecated in version 8.0 and will likely be removed in a future release. Use option MaxRAMFraction instead.");
     output.shouldNotContain("error");
     output.shouldHaveExitValue(0);
   }


### PR DESCRIPTION
TestDefaultMaxRAMFraction.java: JDK 17 still warns for DefaultMaxRAMFraction, but the warning is emitted by the JDK17 hotspot deprecation path with different wording; update the expected text to the JDK17 hotspot message.

Other tests have options removed in JDK 17, so keep them excluded

```
gc/startup_warnings/TestCMSForegroundFlags.java — Options removed: UseCMSCompactAtFullCollection, CMSFullGCsBeforeCompaction, UseCMSCollectionPassing
gc/startup_warnings/TestCMSIncrementalMode.java — Options removed: UseConcMarkSweepGC, CMSIncrementalMode
gc/startup_warnings/TestDefNewCMS.java — Options removed: UseParNewGC, UseConcMarkSweepGC
gc/startup_warnings/TestIncGC.java — Options removed: -Xincgc (CMS incremental mode)
gc/startup_warnings/TestParNewSerialOld.java — Options removed: UseParNewGC

```