### PR TITLE
[Feature] Enable CDS support

### DIFF
--- a/cvm/alt_kernel/src17u/share/classes/java/lang/Thread.java
+++ b/cvm/alt_kernel/src17u/share/classes/java/lang/Thread.java
@@ -1044,6 +1044,15 @@ public class Thread implements Runnable {
     }
 
     /**
+     * Tests if some Thread has been interrupted.  The interrupted state
+     * is cleared or not based on the value of ClearInterrupted that is passed.
+     *
+     * This native method exists only for JDK8 libjava.so registerNatives()
+     * compatibility. Actual interrupt handling uses the {@code interrupted} field.
+     */
+    private native boolean isInterrupted(boolean ClearInterrupted);
+
+    /**
      * Tests if this thread is alive. A thread is alive if it has
      * been started and has not yet died.
      *

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -63,8 +63,6 @@ runtime/6929067/Test6929067.sh
 runtime/6981737/Test6981737.java
 runtime/7110720/Test7110720.sh
 runtime/7162488/Test7162488.sh
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java
 runtime/CheckEndorsedAndExtDirs/EndorsedExtDirs.java
 runtime/ClassFile/UnsupportedClassFileVersion.java
 runtime/CommandLine/PrintFlagsUintxTest.java
@@ -88,19 +86,11 @@ runtime/NMT/JcmdBaselineDetail.java
 runtime/NMT/JcmdDetailDiff.java
 runtime/NMT/JcmdSummaryDiff.java
 runtime/NMT/MallocSiteTypeChange.java
-runtime/NMT/NMTWithCDS.java
 runtime/NMT/ShutdownTwice.java
 runtime/NMT/SummaryAfterShutdown.java
 runtime/NMT/ThreadedVirtualAllocTestType.java
 runtime/NMT/VirtualAllocCommitUncommitRecommit.java
 runtime/NMT/VirtualAllocTestType.java
-runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
-runtime/SharedArchiveFile/CdsSameObjectAlignment.java
-runtime/SharedArchiveFile/LimitSharedSizes.java
-runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java
-runtime/SharedArchiveFile/SharedArchiveFile.java
-runtime/SharedArchiveFile/SharedBaseAddress.java https://github.com/bytedance/CompoundVM/issues/150 linux-aarch64
-runtime/SharedArchiveFile/SpaceUtilizationCheck.java
 serviceability/dcmd/ClassLoaderStatsTest.java
 serviceability/ParserTest.java
 testlibrary_tests/whitebox/vm_flags/DoubleTest.java
@@ -114,3 +104,9 @@ compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
 compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
 compiler/7184394/TestAESMain.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+
+# CDS
+## This test do not supported for hotspot8 after "8072061: Automatically determine optimal sizes for the CDS regions"
+runtime/SharedArchiveFile/LimitSharedSizes.java
+## This test do not supported for hotspot8 after "8232069: Enable CDS even when UseCompressedClassPointers and/or UseCompressedOops are false"
+runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -13,7 +13,6 @@ compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
-compiler/rtm/cli/TestUseRTMLockingOptionOnUnsupportedVM.java
 compiler/startup/NumCompilerThreadsCheck.java
 compiler/tiered/NonTieredLevelsTest.java
 compiler/tiered/LevelTransitionTest.java
@@ -58,8 +57,6 @@ runtime/6929067/Test6929067.sh
 runtime/6981737/Test6981737.java
 runtime/7110720/Test7110720.sh
 runtime/7162488/Test7162488.sh
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java
 runtime/CheckEndorsedAndExtDirs/EndorsedExtDirs.java
 runtime/ClassFile/UnsupportedClassFileVersion.java
 runtime/CommandLine/PrintFlagsUintxTest.java
@@ -84,19 +81,11 @@ runtime/NMT/JcmdDetailDiff.java
 runtime/NMT/JcmdSummaryDiff.java
 runtime/NMT/MallocSiteTypeChange.java
 runtime/NMT/MallocStressTest.java
-runtime/NMT/NMTWithCDS.java
 runtime/NMT/ShutdownTwice.java
 runtime/NMT/SummaryAfterShutdown.java
 runtime/NMT/ThreadedVirtualAllocTestType.java
 runtime/NMT/VirtualAllocCommitUncommitRecommit.java
 runtime/NMT/VirtualAllocTestType.java
-runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
-runtime/SharedArchiveFile/CdsSameObjectAlignment.java
-runtime/SharedArchiveFile/LimitSharedSizes.java
-runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java
-runtime/SharedArchiveFile/SharedArchiveFile.java
-runtime/SharedArchiveFile/SharedBaseAddress.java https://github.com/bytedance/CompoundVM/issues/150 linux-x64
-runtime/SharedArchiveFile/SpaceUtilizationCheck.java
 serviceability/dcmd/ClassLoaderStatsTest.java
 serviceability/ParserTest.java
 testlibrary_tests/whitebox/vm_flags/DoubleTest.java
@@ -109,3 +98,9 @@ compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
 runtime/containers/docker/DockerBasicTest.java
+
+# CDS
+## This test do not supported for hotspot8 after "8072061: Automatically determine optimal sizes for the CDS regions"
+runtime/SharedArchiveFile/LimitSharedSizes.java
+## This test do not supported for hotspot8 after "8232069: Enable CDS even when UseCompressedClassPointers and/or UseCompressedOops are false"
+runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -221,9 +221,9 @@ void DumpRegion::append_intptr_t(intptr_t n, bool need_to_mark) {
 }
 
 void DumpRegion::print(size_t total_bytes) const {
-  log_debug(cds)("%-3s space: " SIZE_FORMAT_W(9) " [ %4.1f%% of total] out of " SIZE_FORMAT_W(9) " bytes [%5.1f%% used] at " INTPTR_FORMAT,
-                 _name, used(), percent_of(used(), total_bytes), reserved(), percent_of(used(), reserved()),
-                 p2i(ArchiveBuilder::current()->to_requested(_base)));
+  log_info(cds)("%s space: " SIZE_FORMAT_W(9) " [ %4.1f%% of total] out of " SIZE_FORMAT_W(9) " bytes [%5.1f%% used] at " INTPTR_FORMAT,
+               _name, used(), percent_of(used(), total_bytes), reserved(), percent_of(used(), reserved()),
+               p2i(ArchiveBuilder::current()->to_requested(_base)));
 }
 
 void DumpRegion::print_out_of_space_msg(const char* failing_region, size_t needed_bytes) {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -487,10 +487,16 @@ void FileMapInfo::allocate_shared_path_table(TRAPS) {
   Arguments::assert_is_dumping_archive();
 
   ClassLoaderData* loader_data = ClassLoaderData::the_null_class_loader_data();
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   ClassPathEntry* jrt = ClassLoader::get_jrt_entry();
 
   assert(jrt != NULL,
          "No modular java runtime image present when allocating the CDS classpath entry table");
+#else
+  // HOTSPOT_TARGET_CLASSLIB == 8: no jrt_entry, boot classpath entries
+  // are all in the first_append_entry list.
+  ClassPathEntry* jrt = ClassLoader::get_first_append_entry();
+#endif
 
   _shared_path_table.dumptime_init(loader_data, CHECK);
 
@@ -579,7 +585,9 @@ int FileMapInfo::num_non_existent_class_paths() {
 
 int FileMapInfo::get_module_shared_path_index(Symbol* location) {
   if (location->starts_with("jrt:", 4) && get_number_of_shared_paths() > 0) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
+#endif
     return 0;
   }
 
@@ -656,6 +664,7 @@ void FileMapInfo::update_jar_manifest(ClassPathEntry *cpe, SharedClassPathEntry*
 }
 
 char* FileMapInfo::skip_first_path_entry(const char* path) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   size_t path_sep_len = strlen(os::path_separator());
   char* p = strstr((char*)path, os::path_separator());
   if (p != NULL) {
@@ -672,6 +681,9 @@ char* FileMapInfo::skip_first_path_entry(const char* path) {
     } );
   }
   return p;
+#else // HOTSPOT_TARGET_CLASSLIB == 8: no modules image to skip
+  return (char*)path;
+#endif
 }
 
 int FileMapInfo::num_paths(const char* path) {
@@ -754,8 +766,12 @@ bool FileMapInfo::validate_boot_class_paths() {
   // common cases, the dump time boot path might contain modules_image only.
   char* runtime_boot_path = Arguments::get_sysclasspath();
   char* rp = skip_first_path_entry(runtime_boot_path);
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
   int dp_len = header()->app_class_paths_start_index() - 1; // ignore the first path to the module image
+#else
+  int dp_len = header()->app_class_paths_start_index(); // no modules image to ignore
+#endif
   bool mismatch = false;
 
   bool relaxed_check = !header()->has_platform_or_app_classes();
@@ -867,7 +883,9 @@ bool FileMapInfo::validate_shared_path_table() {
     //
     // When dynamic archiving is enabled, the _shared_path_table is overwritten
     // to include the application path and stored in the top layer archive.
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
+#endif
     if (header()->app_class_paths_start_index() > 1) {
       DynamicDumpSharedSpaces = false;
       warning(
@@ -914,8 +932,10 @@ bool FileMapInfo::validate_shared_path_table() {
   }
 
   if (header()->max_used_path_index() == 0) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     // default archive only contains the module image in the bootclasspath
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
+#endif
   } else {
     if (!validate_boot_class_paths() || !validate_app_class_paths(shared_app_paths_len)) {
       fail_continue("shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
@@ -1062,10 +1082,12 @@ bool FileMapInfo::init_from_file(int fd) {
     return false;
   }
 
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   if (!Arguments::has_jimage()) {
     FileMapInfo::fail_continue("The shared archive file cannot be used with an exploded module build.");
     return false;
   }
+#endif
 
   unsigned int expected_magic = is_static() ? CDS_ARCHIVE_MAGIC : CDS_DYNAMIC_ARCHIVE_MAGIC;
   if (header()->magic() != expected_magic) {

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -641,9 +641,11 @@ void ClassLoader::setup_bootstrap_search_path_impl(JavaThread* current, const ch
 
 #if INCLUDE_CDS
   if (Arguments::is_dumping_archive()) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     if (!Arguments::has_jimage()) {
       vm_exit_during_initialization("CDS is not supported in exploded JDK build", NULL);
     }
+#endif
   }
 #endif
 
@@ -1321,7 +1323,9 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik, const Cl
     return;
   }
 
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   assert(has_jrt_entry(), "CDS dumping does not support exploded JDK build");
+#endif
 
   ResourceMark rm(current);
   int classpath_index = -1;
@@ -1356,7 +1360,11 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik, const Cl
             classpath_index = i;
             break;
           } else {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
             if ((i >= 1) &&
+#else
+            if ((i >= 0) &&
+#endif
                 (i < ClassLoaderExt::app_class_paths_start_index())) {
               // The class must be from boot loader append path which consists of
               // -Xbootclasspath/a and jvmti appended entries.
@@ -1397,7 +1405,9 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik, const Cl
     // The shared path table is set up after module system initialization.
     // The path table contains no entry before that. Any classes loaded prior
     // to the setup of the shared path table must be from the modules image.
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     assert(stream->from_boot_loader_modules_image(), "stream must be loaded by boot loader from modules image");
+#endif
     assert(FileMapInfo::get_number_of_shared_paths() == 0, "shared path table must not have been setup");
     classpath_index = 0;
   }
@@ -1572,9 +1582,11 @@ void ClassLoader::classLoader_init2(JavaThread* current) {
   // As more modules are defined during module system initialization, more
   // entries will be added to the exploded build array.
   if (!has_jrt_entry()) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
     assert(!DumpSharedSpaces, "DumpSharedSpaces not supported with exploded module builds");
     assert(!DynamicDumpSharedSpaces, "DynamicDumpSharedSpaces not supported with exploded module builds");
     assert(!UseSharedSpaces, "UsedSharedSpaces not supported with exploded module builds");
+#endif
     // Set up the boot loader's _exploded_entries list.  Note that this gets
     // done before loading any classes, by the same thread that will
     // subsequently do the first class load. So, no lock is needed for this.

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -307,6 +307,7 @@ class ClassLoader: AllStatic {
   // Modular java runtime image is present vs. a build with exploded modules
   static bool has_jrt_entry() { return (_jrt_entry != NULL); }
   static ClassPathEntry* get_jrt_entry() { return _jrt_entry; }
+  static ClassPathEntry* get_first_append_entry() { return first_append_entry(); }
   static void close_jrt_image();
 
   // Add a module's exploded directory to the boot loader's exploded module build list

--- a/src/hotspot/share/classfile/classLoader.inline.hpp
+++ b/src/hotspot/share/classfile/classLoader.inline.hpp
@@ -71,8 +71,12 @@ inline void ClassLoader::load_zip_library_if_needed() {
 
 inline int ClassLoader::num_boot_classpath_entries() {
   Arguments::assert_is_dumping_archive();
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   assert(has_jrt_entry(), "must have a java runtime image");
   int num_entries = 1; // count the runtime image
+#else
+  int num_entries = 0; // no runtime image for classlib 8
+#endif
   ClassPathEntry* e = first_append_entry();
   while (e != NULL) {
     num_entries ++;
@@ -82,11 +86,15 @@ inline int ClassLoader::num_boot_classpath_entries() {
 }
 
 inline ClassPathEntry* ClassLoader::get_next_boot_classpath_entry(ClassPathEntry* e) {
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   if (e == ClassLoader::_jrt_entry) {
     return first_append_entry();
   } else {
     return e->next();
   }
+#else // HOTSPOT_TARGET_CLASSLIB == 8: no jrt_entry, just walk the list
+  return e->next();
+#endif
 }
 
 // Helper function used by CDS code to get the number of app classpath

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1452,10 +1452,12 @@ void Arguments::check_unsupported_dumping_properties() {
     sp = sp->next();
   }
 
+#if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9
   // Check for an exploded module build in use with -Xshare:dump.
   if (!has_jimage()) {
     vm_exit_during_initialization("Dumping the shared archive is not supported with an exploded module build");
   }
+#endif
 }
 
 bool Arguments::check_unsupported_cds_runtime_properties() {
@@ -3045,6 +3047,13 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       return JNI_EINVAL;
     }
     LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(class, path));
+  }
+
+  // Enable CDS info logging to stdout during -Xshare:dump, so that
+  // JDK8-compatible CDS dump progress messages (e.g. "Loading classes to share")
+  // are visible without requiring -Xlog:cds=info.
+  if (DumpSharedSpaces) {
+    LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(cds));
   }
 
   fix_appclasspath();


### PR DESCRIPTION
Fix CDS (Class Data Sharing) to work correctly when the JDK17 VM is compiled with --with-hotspot-target-classlib=8 (JDK8 class library).

Issue: https://github.com/bytedance/CompoundVM/issues/150

## 背景
CompoundVM 项目使用 JDK17 HotSpot VM + JDK8 类库的混合构建（--with-hotspot-target-classlib=8）。在此构建模式下，JDK8 没有模块化的 lib/modules jimage 文件，而 JDK17 的 CDS 实现在多处假定该文件一定存在，导致 -Xshare:dump 失败并报错 "CDS is not supported in exploded JDK build"。

## 修改概要
共修改 7 个 C++ 文件 + 1 个 Java 文件：

1. CDS 核心适配（classLoader / filemap / arguments）

JDK17 CDS 代码中有多处检查 has_jimage() 和 has_jrt_entry() 的地方，这些检查对 JDK9+ 模块化构建是正确的，但对 JDK8 类库构建不适用。修改策略：用 #if !defined(HOTSPOT_TARGET_CLASSLIB) || HOTSPOT_TARGET_CLASSLIB >= 9 守卫这些检查点，使它们在 classlib=8 时被跳过。

具体改动包括：

- CDS dump 时的 jimage 检查（3 处 vm_exit / fail_continue）
- CDS dump 时的 has_jrt_entry() 断言（record_result() / classLoader_init2()）
- Boot classpath index 范围适配（classlib 8 下从 i >= 0 开始，因为没有 index 0 的 jrt_entry）
- CDS shared path table 构造：用 get_first_append_entry() 替代 get_jrt_entry() 作为 boot classpath 遍历起点
- skip_first_path_entry()：classlib 8 下无需跳过 modules image
- Archive 验证阶段的多处 shared_path(0)->is_modules_image() 断言守卫

2. CDS helper 函数适配（classLoader.inline.hpp）

- num_boot_classpath_entries(): classlib 8 下计数从 0 开始（无 jrt_entry 计入）
- get_next_boot_classpath_entry(): classlib 8 下无需 jrt -> append 桥接

3. CDS dump 输出兼容（arguments.cpp / archiveUtils.cpp）

- -Xshare:dump 时自动启用 log_info(cds) 输出到 stdout，使JDK8兼容的进度信息（如 "Loading classes to share"）可见
- DumpRegion::print() 日志级别从 log_debug 提升至 log_info
- 修复格式字符串 "%-3s space:" -> "%s space:"，消除多余空格

4. alt_kernel 兼容（Thread.java）

- 添加 private native boolean isInterrupted(boolean) 方法声明。该方法仅用于 JDK8 libjava.so 中 registerNatives() 的兼容性绑定，不会被实际调用（alt_kernel 的 Thread 使用字段读写方式处理中断状态）。

## 本地测试验证
如下几个测试在本地已经全部测试通过，没有新增测试失败

- [x] make -f cvm.mk test_jtreg8_jdk_tier1
- [x] make -f cvm.mk test_jtreg8_langtools
- [x] make -f cvm.mk test_jtreg8_hotspot8
- [x] make -f cvm.mk test_jtreg8_cvm8
- [x] make -f cvm.mk test_gtest_hotspot17

## 已知限制

1. runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java用例不适合hotspot8，原因见Problemlist注释
2. runtime/SharedArchiveFile/LimitSharedSizes.java用例不适合hotsport8，原因见Problemlist注释
