### PR TITLE
[Test] Move two false-passing tests to the whitelist

### DIFF
--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -42,6 +42,7 @@ gc/g1/TestStringDeduplicationYoungGC.java
 gc/g1/TestStringSymbolTableStats.java
 gc/logging/TestGCId.java
 gc/metaspace/TestMetaspaceSizeFlags.java
+gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
 gc/parallelScavenge/AdaptiveGCBoundary.java
 gc/startup_warnings/TestCMSForegroundFlags.java
 gc/startup_warnings/TestCMSIncrementalMode.java
@@ -103,6 +104,7 @@ runtime/SharedArchiveFile/SharedBaseAddress.java https://github.com/bytedance/Co
 runtime/SharedArchiveFile/SpaceUtilizationCheck.java
 serviceability/dcmd/ClassLoaderStatsTest.java
 serviceability/ParserTest.java
+serviceability/sa/jmap-hashcode/Test8028623.java
 testlibrary_tests/whitebox/vm_flags/DoubleTest.java
 testlibrary_tests/whitebox/vm_flags/IntxTest.java
 runtime/NMT/MallocStressTest.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -37,6 +37,7 @@ gc/g1/TestStringDeduplicationYoungGC.java
 gc/g1/TestStringSymbolTableStats.java
 gc/logging/TestGCId.java
 gc/metaspace/TestMetaspaceSizeFlags.java
+gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
 gc/parallelScavenge/AdaptiveGCBoundary.java
 gc/startup_warnings/TestCMSForegroundFlags.java
 gc/startup_warnings/TestCMSIncrementalMode.java
@@ -99,6 +100,7 @@ runtime/SharedArchiveFile/SharedBaseAddress.java https://github.com/bytedance/Co
 runtime/SharedArchiveFile/SpaceUtilizationCheck.java
 serviceability/dcmd/ClassLoaderStatsTest.java
 serviceability/ParserTest.java
+serviceability/sa/jmap-hashcode/Test8028623.java
 testlibrary_tests/whitebox/vm_flags/DoubleTest.java
 testlibrary_tests/whitebox/vm_flags/IntxTest.java
 testlibrary_tests/TestMutuallyExclusivePlatformPredicates.java


### PR DESCRIPTION
GitHub Actions’ default CI environment does not allow ptrace, causing the following two tests to skip the code paths they are intended to verify while still reporting success:

* gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
* serviceability/sa/jmap-hashcode/Test8028623.java

As a result, these tests produce false-positive results in CI. This commit moves both tests to the whitelist to avoid misleading test results. A proper fix will be implemented in a follow-up change.