### PR TITLE
[Test] Fix CrashReportTest to support non-product builds

### DIFF
--- a/cvm/test/hotspot/runtime/version/CrashReportTest.java
+++ b/cvm/test/hotspot/runtime/version/CrashReportTest.java
@@ -136,7 +136,7 @@ public class CrashReportTest {
     private static void verifyJREVersion(List<String> lines) throws Exception {
         Pattern pattern = Pattern.compile(
                 "# JRE version:.*" + Pattern.quote(EXPECTED_VENDOR_VERSION)
-                        + ".*\\(build " + Pattern.quote(EXPECTED_RUNTIME_VERSION) + "\\)");
+                        + ".*\\((?:fastdebug |slowdebug )?build " + Pattern.quote(EXPECTED_RUNTIME_VERSION) + "\\)");
         for (String line : lines) {
             if (pattern.matcher(line).find()) {
                 System.out.println("PASS: JRE version line contains vendor version and runtime version.");


### PR DESCRIPTION
The hs_err JRE version line format differs between product and non-product builds. For product builds the line contains "(build <version>)", while for fastdebug/slowdebug builds it contains "(fastdebug build <version>)" or "(slowdebug build <version>)". The test regex previously only matched the product build format, causing the test to fail on fastdebug/slowdebug builds.

Fix the regex to optionally match the debug level prefix before "build":
  \(build  ->  \((?:fastdebug |slowdebug )?build

Issue: #163