### PR TITLE
[fix] Recognize CVM as server VM in test Platform

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -449,6 +449,7 @@ endif
 	$(call overlay_single,jdk8u,hotspot/test/gc/arguments/TestUseCompressedOopsErgoTools.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/testlibrary/whitebox/sun/hotspot/WhiteBox.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/compiler/whitebox/IsMethodCompilableTest.java, $(JDK8_SRCROOT))
 
 -overlay-jtreg:
 	$(call overlay_single,jdk8u,test/jtreg-ext/requires/VMProps.java, $(JDK8_SRCROOT))

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -8,7 +8,6 @@ compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
 compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
 compiler/profiling/spectrapredefineclass/Launcher.java
-compiler/rtm/cli/TestPrintPreciseRTMLockingStatisticsOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestRTMAbortThresholdOption.java
 compiler/rtm/cli/TestRTMLockingCalculationDelayOption.java
@@ -18,6 +17,7 @@ compiler/rtm/cli/TestRTMSpinLoopCountOption.java
 compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestUseRTMLockingOptionOnUnsupportedCPU.java 0000000 linux-aarch64 # This test failed since IgnoreUnrecognizedVMOptions seted to true by default in cvm
 compiler/rtm/cli/TestUseRTMXendForLockBusyOption.java
 compiler/startup/NumCompilerThreadsCheck.java
 compiler/tiered/NonTieredLevelsTest.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -8,7 +8,6 @@ compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
 compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
 compiler/profiling/spectrapredefineclass/Launcher.java
-compiler/rtm/cli/TestPrintPreciseRTMLockingStatisticsOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java

--- a/cvm/overlay/jdk8u/hotspot/test/compiler/whitebox/IsMethodCompilableTest.java
+++ b/cvm/overlay/jdk8u/hotspot/test/compiler/whitebox/IsMethodCompilableTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test IsMethodCompilableTest
+ * @bug 8007270 8006683 8007288 8022832
+ * @library /testlibrary /testlibrary/whitebox /testlibrary/com/oracle/java/testlibrary
+ * @build IsMethodCompilableTest
+ * @run main ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main ClassFileInstaller com.oracle.java.testlibrary.Platform
+ * @run main/othervm/timeout=2400 -Xbootclasspath/a:. -Xmixed -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:PerMethodRecompilationCutoff=3 -XX:CompileCommand=compileonly,SimpleTestCase$Helper::* IsMethodCompilableTest
+ * @summary testing of WB::isMethodCompilable()
+ * @author igor.ignatyev@oracle.com
+ */
+
+import com.oracle.java.testlibrary.Platform;
+
+public class IsMethodCompilableTest extends CompilerWhiteBoxTest {
+    /**
+     * Value of {@code -XX:PerMethodRecompilationCutoff}
+     */
+    protected static final long PER_METHOD_RECOMPILATION_CUTOFF;
+
+    static {
+        long tmp = Long.parseLong(
+                getVMOption("PerMethodRecompilationCutoff", "400"));
+        if (tmp == -1) {
+            PER_METHOD_RECOMPILATION_CUTOFF = -1 /* Inf */;
+        } else {
+            PER_METHOD_RECOMPILATION_CUTOFF = (0xFFFFFFFFL & tmp);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        CompilerWhiteBoxTest.main(IsMethodCompilableTest::new, args);
+    }
+
+    private IsMethodCompilableTest(TestCase testCase) {
+        super(testCase);
+        // to prevent inlining of #method
+        WHITE_BOX.testSetDontInlineMethod(method, true);
+    }
+
+    /**
+     * Tests {@code WB::isMethodCompilable()} by recompilation of tested method
+     * 'PerMethodRecompilationCutoff' times and checks compilation status. Also
+     * checks that WB::clearMethodState() clears no-compilable flags. Only
+     * applicable to c2 compiled methods.
+     *
+     * @throws Exception if one of the checks fails.
+     */
+    @Override
+    protected void test() throws Exception {
+        // Only c2 compilations can be disabled through PerMethodRecompilationCutoff
+        if (!Platform.isServer()) {
+            System.out.println("Not server VM, test SKIPPED");
+            return;
+        }
+
+        if (skipXcompOSR()) {
+          return;
+        }
+        if (!isCompilable(COMP_LEVEL_FULL_OPTIMIZATION)) {
+            throw new RuntimeException(method + " must be compilable");
+        }
+        System.out.println("PerMethodRecompilationCutoff = "
+                + PER_METHOD_RECOMPILATION_CUTOFF);
+        if (PER_METHOD_RECOMPILATION_CUTOFF == -1) {
+            System.err.println(
+                    "Warning: test is not applicable if PerMethodRecompilationCutoff == Inf");
+            return;
+        }
+
+        // deoptimize 'PerMethodRecompilationCutoff' times
+        for (long attempts = 0, successes = 0;
+               (successes < PER_METHOD_RECOMPILATION_CUTOFF)  &&
+               (attempts < PER_METHOD_RECOMPILATION_CUTOFF*2) &&
+               isCompilable(COMP_LEVEL_FULL_OPTIMIZATION); attempts++) {
+            if (compileAndDeoptimize() == COMP_LEVEL_FULL_OPTIMIZATION) {
+                successes++;
+            }
+        }
+
+        if (!testCase.isOsr() && !isCompilable(COMP_LEVEL_FULL_OPTIMIZATION)) {
+            // in osr test case count of deopt maybe more than iterations
+            throw new RuntimeException(method + " is not compilable after "
+                    + PER_METHOD_RECOMPILATION_CUTOFF + " iterations");
+        }
+
+        // Now compile once more
+        compileAndDeoptimize();
+
+        if (isCompilable(COMP_LEVEL_FULL_OPTIMIZATION)) {
+            throw new RuntimeException(method + " is still compilable after "
+                    + PER_METHOD_RECOMPILATION_CUTOFF + " iterations");
+        }
+        checkNotCompiled();
+        compile();
+        waitBackgroundCompilation();
+        checkNotCompiled(COMP_LEVEL_FULL_OPTIMIZATION);
+
+        // WB.clearMethodState() must reset no-compilable flags
+        WHITE_BOX.clearMethodState(method);
+        if (!isCompilable(COMP_LEVEL_FULL_OPTIMIZATION)) {
+            throw new RuntimeException(method
+                    + " is not compilable after clearMethodState()");
+        }
+        compile();
+        checkCompiled();
+    }
+
+    private int compileAndDeoptimize() throws Exception {
+        compile();
+        waitBackgroundCompilation();
+        int compLevel = getCompLevel();
+        deoptimize();
+        return compLevel;
+    }
+}

--- a/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/Platform.java
+++ b/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/Platform.java
@@ -42,7 +42,7 @@ public class Platform {
     }
 
     public static boolean isServer() {
-        return vmName.endsWith(" Server VM");
+        return vmName.contains(" Server VM");
     }
 
     public static boolean isCVM() {

--- a/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/cli/CommandLineOptionTest.java
+++ b/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/cli/CommandLineOptionTest.java
@@ -293,7 +293,9 @@ public abstract class CommandLineOptionTest {
      * @throws RuntimeException when VM type is unknown.
      */
     private static String getVMTypeOption() {
-        if (Platform.isServer()) {
+        if (Platform.isCVM()) {
+            return "-cvm";
+        } else if (Platform.isServer()) {
             return "-server";
         } else if (Platform.isClient()) {
             return "-client";
@@ -301,8 +303,6 @@ public abstract class CommandLineOptionTest {
             return "-minimal";
         } else if (Platform.isGraal()) {
             return "-graal";
-        } else if (Platform.isCVM()) {
-            return "-cvm";
         }
         throw new RuntimeException("Unknown VM mode.");
     }


### PR DESCRIPTION
CVM's java.vm.name (e.g. "OpenJDK 64-Bit Server VM (CompoundVM 8.17.4)") does not end with " Server VM", so Platform.isServer() returned false even though CVM is a C2-capable Server VM derivative. This misclassified CVM as a non-server VM, routing RTM CLI tests into the "unsupported VM" code path (e.g. TestPrintPreciseRTMLockingStatisticsOptionOn UnsupportedConfig expected an "Unrecognized VM option" error) and silently skipping C2-dependent tests.

Fix:
- Platform.isServer(): also return true for CVM so it is treated as a server-class VM.
- CommandLineOptionTest.getVMTypeOption(): check Platform.isCVM() before Platform.isServer(), so CVM sub-processes are still launched with -cvm rather than -server, preserving the "same VM type as current" contract now that isServer() is true for CVM.
- IsMethodCompilableTest: print "Not server VM, test SKIPPED" when skipping, consistent with other whitebox tests.

Issue: #166