### PR TITLE
[Test] Remove duplicate JDK 8 exclusions

### DIFF
--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -60,7 +60,6 @@ gc/TestMemoryMXBeansAndPoolsPresence.java
 gc/TestVerifyDuringStartup.java
 gc/TestVerifySilently.java
 gc/TestVerifySubSet.java
-runtime/6929067/Test6929067.sh
 runtime/6981737/Test6981737.java
 runtime/7110720/Test7110720.sh
 runtime/7162488/Test7162488.sh
@@ -79,7 +78,6 @@ runtime/containers/docker/TestCPUAwareness.java
 runtime/containers/docker/TestMemoryAwareness.java
 runtime/contended/Options.java
 runtime/InternalApi/ThreadCpuTimesDeadlock.java
-runtime/InitialThreadOverflow/testme.sh
 runtime/containers/docker/TestMisc.java
 runtime/invokedynamic/BootstrapMethodErrorTest.java
 runtime/Metaspace/MaxMetaspaceSizeTest.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -56,7 +56,6 @@ gc/TestMemoryMXBeansAndPoolsPresence.java
 gc/TestVerifyDuringStartup.java
 gc/TestVerifySilently.java
 gc/TestVerifySubSet.java
-runtime/6929067/Test6929067.sh
 runtime/6981737/Test6981737.java
 runtime/7110720/Test7110720.sh
 runtime/7162488/Test7162488.sh
@@ -75,7 +74,6 @@ runtime/containers/docker/TestCPUAwareness.java
 runtime/containers/docker/TestMemoryAwareness.java
 runtime/contended/Options.java
 runtime/InternalApi/ThreadCpuTimesDeadlock.java
-runtime/InitialThreadOverflow/testme.sh
 runtime/containers/docker/TestMisc.java
 runtime/invokedynamic/BootstrapMethodErrorTest.java
 runtime/Metaspace/MaxMetaspaceSizeTest.java


### PR DESCRIPTION
## Problem

`runtime/6929067/Test6929067.sh` and `runtime/InitialThreadOverflow/testme.sh` are already excluded for `generic-all` platforms by the JDK 8 `hotspot/test/ProblemList.txt`. Keeping the same entries in CompoundVM's architecture-specific x64 and aarch64 exclusion lists is redundant and makes those lists harder to audit.

## Solution

Remove both duplicate entries from:

- `cvm/conf/jtreg_hotspot8_excludes_x64.list`
- `cvm/conf/jtreg_hotspot8_excludes_aarch64.list`

No test behavior changes: the upstream `generic-all` exclusions remain in effect for both architectures.

## Validation

- Confirmed both test paths are present with `generic-all` in the current `openjdk/jdk8u-dev` `hotspot/test/ProblemList.txt`.
- Confirmed neither path remains in CompoundVM's repository-specific exclusion lists.
- `git diff --check`

Fixes #165
