### PR TITLE
[Test] Fix Platform.isDebugBuild() for JDK 8

### DIFF
--- a/cvm.mk
+++ b/cvm.mk
@@ -457,6 +457,7 @@ endif
 	$(call overlay_single,jdk8u,hotspot/test/testlibrary/whitebox/sun/hotspot/WhiteBox.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/gc/startup_warnings/TestDefaultMaxRAMFraction.java, $(JDK8_SRCROOT))
 	$(call overlay_single,jdk8u,hotspot/test/compiler/whitebox/IsMethodCompilableTest.java, $(JDK8_SRCROOT))
+	$(call overlay_single,jdk8u,hotspot/test/runtime/ErrorHandling/ErrorFileRedirectTest.java, $(JDK8_SRCROOT))
 
 -overlay-jtreg:
 	$(call overlay_single,jdk8u,test/jtreg-ext/requires/VMProps.java, $(JDK8_SRCROOT))

--- a/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_aarch64.list
@@ -116,3 +116,6 @@ compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
 compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
 compiler/7184394/TestAESMain.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+
+# RunUnitTestsConcurrently.java was moved to CVM hotspot gtest.
+runtime/memory/RunUnitTestsConcurrently.java

--- a/cvm/conf/jtreg_hotspot8_excludes_x64.list
+++ b/cvm/conf/jtreg_hotspot8_excludes_x64.list
@@ -8,7 +8,9 @@ compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
 compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
 compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
 compiler/profiling/spectrapredefineclass/Launcher.java
+compiler/rtm/cli/TestRTMAbortRatioOptionOnSupportedConfig.java
 compiler/rtm/cli/TestRTMAbortRatioOptionOnUnsupportedConfig.java
+compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnSupportedConfig.java
 compiler/rtm/cli/TestRTMTotalCountIncrRateOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMDeoptOptionOnUnsupportedConfig.java
 compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
@@ -110,3 +112,6 @@ compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
 compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
 runtime/containers/docker/DockerBasicTest.java
+
+# RunUnitTestsConcurrently.java was moved to CVM hotspot gtest.
+runtime/memory/RunUnitTestsConcurrently.java

--- a/cvm/overlay/jdk8u/hotspot/test/runtime/ErrorHandling/ErrorFileRedirectTest.java
+++ b/cvm/overlay/jdk8u/hotspot/test/runtime/ErrorHandling/ErrorFileRedirectTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, SAP. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @bug 8220786
+ * @summary Test ErrorFileToStderr and ErrorFileToStdout
+ * @library /testlibrary
+ */
+
+import com.oracle.java.testlibrary.OutputAnalyzer;
+import com.oracle.java.testlibrary.Platform;
+import com.oracle.java.testlibrary.ProcessTools;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class ErrorFileRedirectTest {
+
+  public static void do_test(boolean redirectStdout, boolean redirectStderr) throws Exception {
+
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Xmx64M",
+            "-XX:ErrorHandlerTest=14",
+            "-XX:" + (redirectStdout ? "+" : "-") + "ErrorFileToStdout",
+            "-XX:" + (redirectStderr ? "+" : "-") + "ErrorFileToStderr",
+            "-version");
+
+    OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
+
+    // we should have crashed with a SIGSEGV
+    output_detail.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
+    output_detail.shouldMatch("# +(?:SIGSEGV|EXCEPTION_ACCESS_VIOLATION).*");
+
+    // If no redirection happened, we should find a mention of the file in the output.
+    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
+    if (redirectStdout == false && redirectStderr == false) {
+      if (hs_err_file == null) {
+        throw new RuntimeException("Expected hs-err file but none found.");
+      } else {
+        System.out.println("Found hs error file mentioned as expected: " + hs_err_file);
+      }
+    } else {
+      if (hs_err_file != null) {
+        throw new RuntimeException("Found unexpected mention of hs-err file (we did redirect the output so no file should have been written).");
+      } else {
+        System.out.println("No mention of an hs-err file - ok! ");
+      }
+    }
+
+    // Check the output. Note that since stderr was specified last it has preference if both are set.
+    if (redirectStdout == true && redirectStderr == false) {
+      output_detail.stdoutShouldContain("---------------  T H R E A D  ---------------");
+      output_detail.stderrShouldNotContain("---------------  T H R E A D  ---------------");
+      System.out.println("Found report on stderr - ok! ");
+    } else if (redirectStderr == true) {
+      output_detail.stderrShouldContain("---------------  T H R E A D  ---------------");
+      output_detail.stdoutShouldNotContain("---------------  T H R E A D  ---------------");
+      System.out.println("Found report on stdout - ok! ");
+    }
+
+    System.out.println("OK.");
+
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (!Platform.isDebugBuild()) {
+      System.out.println("Skip on non-debug builds since we need '-XX:ErrorHandlerTest'");
+      return;
+    }
+    do_test(false, false);
+    do_test(false, true);
+    do_test(true, false);
+    do_test(true, true);
+  }
+
+}
+
+

--- a/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/Platform.java
+++ b/cvm/overlay/jdk8u/hotspot/test/testlibrary/com/oracle/java/testlibrary/Platform.java
@@ -36,6 +36,7 @@ public class Platform {
     private static final String osArch      = System.getProperty("os.arch");
     public static final String vmName      = System.getProperty("java.vm.name");
     private static final String userName    = System.getProperty("user.name");
+    private static final String rtVersion   = System.getProperty("java.runtime.version");
 
     public static boolean isClient() {
         return vmName.endsWith(" Client VM");
@@ -98,7 +99,7 @@ public class Platform {
     }
 
     public static boolean isDebugBuild() {
-        return vmVersion.toLowerCase().contains("debug");
+        return (rtVersion.toLowerCase().contains("debug"));
     }
 
     public static String getVMVersion() {

--- a/cvm/overlay/jdk8u/jdk/test/lib/testlibrary/jdk/testlibrary/Platform.java
+++ b/cvm/overlay/jdk8u/jdk/test/lib/testlibrary/jdk/testlibrary/Platform.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.testlibrary;
+
+public class Platform {
+    private static final String osName      = System.getProperty("os.name");
+    private static final String dataModel   = System.getProperty("sun.arch.data.model");
+    private static final String vmVersion   = System.getProperty("java.vm.version");
+    private static final String osArch      = System.getProperty("os.arch");
+    private static final String rtVersion   = System.getProperty("java.runtime.version");
+
+    public static boolean is32bit() {
+        return dataModel.equals("32");
+    }
+
+    public static boolean is64bit() {
+        return dataModel.equals("64");
+    }
+
+    public static boolean isSolaris() {
+        return isOs("sunos");
+    }
+
+    public static boolean isWindows() {
+        return isOs("win");
+    }
+
+    public static boolean isOSX() {
+        return isOs("mac");
+    }
+
+    public static boolean isLinux() {
+        return isOs("linux");
+    }
+
+    private static boolean isOs(String osname) {
+        return osName.toLowerCase().startsWith(osname.toLowerCase());
+    }
+
+    public static String getOsName() {
+        return osName;
+    }
+
+    public static boolean isDebugBuild() {
+        return (rtVersion.toLowerCase().contains("debug"));
+    }
+
+    public static String getVMVersion() {
+        return vmVersion;
+    }
+
+    // Returns true for sparc and sparcv9.
+    public static boolean isSparc() {
+        return isArch("sparc");
+    }
+
+    public static boolean isARM() {
+        return isArch("arm");
+    }
+
+    public static boolean isPPC() {
+        return isArch("ppc");
+    }
+
+    public static boolean isX86() {
+        // On Linux it's 'i386', Windows 'x86'
+        return (isArch("i386") || isArch("x86"));
+    }
+
+    public static boolean isX64() {
+        // On OSX it's 'x86_64' and on other (Linux, Windows and Solaris) platforms it's 'amd64'
+        return (isArch("amd64") || isArch("x86_64"));
+    }
+
+    private static boolean isArch(String archname) {
+        return osArch.toLowerCase().startsWith(archname.toLowerCase());
+    }
+
+    public static String getOsArch() {
+        return osArch;
+    }
+
+}


### PR DESCRIPTION
Fix the flawed debug build detection in Platform.isDebugBuild() under jdk/test, which causes debug build tests to fail.

It looks like #160 and #167 together caused the failure targeted by this PR.